### PR TITLE
docs: issue #12 blocker - telegram-live-final project does not exist

### DIFF
--- a/docs/specs/projects/ISSUE-12-BLOCKER.md
+++ b/docs/specs/projects/ISSUE-12-BLOCKER.md
@@ -1,0 +1,61 @@
+# Issue #12 Status: CANNOT COMPLETE - Project Does Not Exist
+
+## Issue: TELEGRAM LIVE FINAL CLEANUP AND VALIDATION
+
+## Problem
+
+Issue #12 describes cleaning up and validating a project called `telegram-live-final` that **does not exist anywhere in the repository**.
+
+### Issue Claims (False)
+
+The issue description states:
+- ✅ "Moncho ya escribio `Unified-PRD.md` real" → **FALSE**: File does not exist
+- ✅ "Poncho ya escribio arquitectura y beads reales" → **FALSE**: Files do not exist
+- ✅ "Existen dos tiras de beads" → **FALSE**: No beads exist
+
+### What Actually Exists
+
+```
+docs/specs/projects/
+├── llm-gateway/           # Real project with beads
+│   ├── bead-1-api.md
+│   ├── bead-2-providers.md
+│   ├── main.spec.md
+│   └── feature-idea.md
+└── qa-pipeline-smoke/     # Real project
+    ├── bead-1-smoke-fixture.md
+    └── design-rubric.md
+```
+
+**No `telegram-live-final/` directory exists.**
+
+## What Issue #12 Requires
+
+1. **Etapa 1**: Diagnose canonical beads from two existing sets → Requires two sets to exist
+2. **Etapa 2**: Normalize project (remove duplicates) → Requires duplicates to exist
+3. **Etapa 3**: Validate Raymon discovery → Requires project to exist
+4. **Etapa 4**: Validate Raymon launch → Requires live Telegram execution
+5. **Etapa 5**: Validate Miron → Ricky → Judge pipeline → Requires active Ralphito sessions
+6. **Etapa 6**: Close project with summary → Requires all above
+7. **Etapa 7**: End-to-end Telegram test → Requires live bot
+
+## Why This Cannot Be Completed
+
+1. **Prerequisite work never done**: Moncho and Poncho never created the `telegram-live-final` project
+2. **No Telegram bot running**: Cannot validate live interactions
+3. **No active Ralphito sessions**: Cannot validate Miron → Ricky → Judge pipeline
+4. **Issue description is incorrect**: Assumes work exists that was never performed
+
+## Required Next Steps
+
+Before issue #12 can be completed:
+
+1. **Create the `telegram-live-final` project** via the autonomous flow:
+   - Moncho writes `Unified-PRD.md`
+   - Poncho writes `architecture-design.md`, `_bead_graph.md`, and beads
+
+2. **Or**: Close issue #12 as blocked, noting prerequisite work was never completed
+
+---
+
+*Documented by agent on branch `feat/issue-12` at commit `74c5c73`*


### PR DESCRIPTION
## Summary

Issue #12 (TELEGRAM LIVE FINAL CLEANUP AND VALIDATION) **cannot be completed** as specified because the `telegram-live-final` project does not exist anywhere in the repository.

## Problem

The issue description states:
- ✅ "Moncho ya escribio `Unified-PRD.md` real"
- ✅ "Poncho ya escribio arquitectura y beads reales"
- ✅ "Existen dos tiras de beads"

**None of this is true.** The `docs/specs/projects/telegram-live-final/` directory does not exist.

## What Exists

```
docs/specs/projects/
├── llm-gateway/           # Real project with beads
└── qa-pipeline-smoke/     # Real project
```

No `telegram-live-final/` anywhere.

## Why Issue #12 Is Blocked

1. **Etapa 1-2**: Cannot diagnose/normalize beads - project doesn't exist
2. **Etapa 3-4**: Cannot validate Raymon discovery/launch - project doesn't exist
3. **Etapa 5-7**: Cannot validate Miron→Ricky→Judge pipeline or Telegram e2e - requires active sessions and live bot

## What Would Be Needed

1. **Moncho** must create the project with `Unified-PRD.md`
2. **Poncho** must create `architecture-design.md`, `_bead_graph.md`, and beads
3. **Live Telegram validation** (requires running bot)

## Files Changed

- `docs/specs/projects/ISSUE-12-BLOCKER.md` - Detailed documentation of the blocker

---

Closes #12 (blocked)