### PR TITLE
fix(ao): harden worktree lookup and spawn metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.ralphito-session.json
 .env
 .env.*
 !.env.example

--- a/scripts/lib/ao-paths.sh
+++ b/scripts/lib/ao-paths.sh
@@ -4,12 +4,54 @@ ao_data_dir() {
     printf '%s\n' "${AO_DATA_DIR:-$HOME/.agent-orchestrator}"
 }
 
+ao_worktree_roots() {
+    printf '%s\n' "$HOME/.worktrees"
+    printf '%s\n' "$(ao_data_dir)"
+}
+
 find_ao_worktree() {
     local session_id="$1"
+    local root
+    local match=""
 
-    find "$(ao_data_dir)" -type d -path "*/worktrees/$session_id" 2>/dev/null | head -n 1
+    while IFS= read -r root; do
+        [ -d "$root" ] || continue
+        match=$(find "$root" -type d \( -path "*/worktrees/$session_id" -o -path "*/$session_id" \) 2>/dev/null | head -n 1 || true)
+        if [ -n "$match" ]; then
+            printf '%s\n' "$match"
+            return 0
+        fi
+    done < <(ao_worktree_roots)
+
+    return 1
+}
+
+wait_for_ao_worktree() {
+    local session_id="$1"
+    local timeout_seconds="${2:-20}"
+    local started_at="$(date +%s)"
+    local match=""
+
+    while true; do
+        match=$(find_ao_worktree "$session_id" || true)
+        if [ -n "$match" ]; then
+            printf '%s\n' "$match"
+            return 0
+        fi
+
+        if [ $(( $(date +%s) - started_at )) -ge "$timeout_seconds" ]; then
+            return 1
+        fi
+
+        sleep 1
+    done
 }
 
 find_ao_guardrail_logs() {
-    find "$(ao_data_dir)" -type f -name ".guardrail_error.log" 2>/dev/null
+    local root
+
+    while IFS= read -r root; do
+        [ -d "$root" ] || continue
+        find "$root" -type f -name ".guardrail_error.log" 2>/dev/null
+    done < <(ao_worktree_roots)
 }

--- a/scripts/tools/tool_spawn_executor.sh
+++ b/scripts/tools/tool_spawn_executor.sh
@@ -1,81 +1,284 @@
 #!/bin/bash
-# Uso: ./tool_spawn_executor <proyecto> <prompt_o_spec_path>
-# Ejemplo: ./tool_spawn_executor backend-team "Lee docs/specs/tarea1.md y ejecútala"
 
 set -euo pipefail
 
+# Uso: ./tool_spawn_executor.sh <proyecto> <prompt_o_spec_path>
+#    o ./tool_spawn_executor.sh --payload-file <ruta.json>
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCKS_FILE="$SCRIPT_DIR/.locks.jsonl"
 
-PROJECT=$1
-PROMPT=$2
-LOCKS_FILE="$SCRIPT_DIR/.locks.json"
+source "$SCRIPT_DIR/../lib/ao-paths.sh"
 
-if [ -z "$PROJECT" ] || [ -z "$PROMPT" ]; then
-    echo '{"error": "Faltan argumentos. Uso: tool_spawn_executor <proyecto> <prompt_o_spec_path>"}'
-    exit 1
-fi
+json_escape() {
+    python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+}
 
-# 1. Intentamos extraer la ruta al archivo bead desde el prompt (si la hay)
-BEAD_PATH=$(echo "$PROMPT" | grep -o 'docs/specs/[^ ]*bead[^ ]*\.md' | head -n 1 || true)
-BEAD_FILE=""
+extract_payload_field() {
+    local payload_file="$1"
+    local field_name="$2"
 
-if [ -n "$BEAD_PATH" ]; then
-    BEAD_FILE="$REPO_ROOT/$BEAD_PATH"
-fi
-
-if [ -n "$BEAD_FILE" ] && [ -f "$BEAD_FILE" ]; then
-    # Extraemos el WRITE_ONLY_GLOBS del archivo
-    WRITE_GLOBS=$(grep '\[WRITE_ONLY_GLOBS\]:' "$BEAD_FILE" | cut -d':' -f2-)
-    
-    if [ -n "$WRITE_GLOBS" ]; then
-        # Normalizamos la cadena para comparar
-        NORMALIZED_GLOBS=$(echo "$WRITE_GLOBS" | tr -d ' ' | tr -d '"' | tr -d '[' | tr -d ']')
-        
-        # Comprobamos el lock
-        if grep -q "\"$NORMALIZED_GLOBS\"" "$LOCKS_FILE" 2>/dev/null; then
-            echo '{"status": "error", "message": "MUTEX COLLISION: Otro Ralphito ya está editando '$NORMALIZED_GLOBS'. Pon este Bead en cola y lanza otro distinto."}'
-            exit 1
-        fi
-        
-        # Registramos el lock (esto es muy básico, en producción usaríamos jq)
-        echo "{\"lock\": \"$NORMALIZED_GLOBS\", \"bead\": \"$BEAD_PATH\"}" >> "$LOCKS_FILE"
-    fi
-fi
-
-echo "🚀 Spawned Ralphito para el proyecto: $PROJECT" >&2
-echo "Instrucción: $PROMPT" >&2
-
-# Ejecutamos ao spawn sin issue para evitar colisiones de branch derivadas del prompt.
-# Luego enviamos el prompt al Ralphito ya creado.
-SPAWN_LOG="/tmp/spawn_output_$$.log"
-SEND_LOG="/tmp/send_output_$$.log"
-
-if ao spawn "$PROJECT" > "$SPAWN_LOG" 2>&1; then
-    SESSION_ID=$(python3 - <<'PY' "$SPAWN_LOG"
+    python3 - <<'PY' "$payload_file" "$field_name"
+import json
 import sys
 
-session_id = ""
-with open(sys.argv[1], encoding="utf-8") as f:
-    for line in f:
-        if line.startswith("SESSION="):
-            session_id = line.strip().split("=", 1)[1]
+payload_path, field_name = sys.argv[1], sys.argv[2]
+with open(payload_path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+value = payload.get(field_name)
+if value is None:
+    raise SystemExit(0)
+
+if isinstance(value, (dict, list)):
+    print(json.dumps(value, ensure_ascii=True))
+else:
+    print(value)
+PY
+}
+
+compute_bead_hash() {
+    local bead_file="$1"
+
+    if [ ! -f "$bead_file" ]; then
+        return 0
+    fi
+
+    sha256sum "$bead_file" | cut -d' ' -f1
+}
+
+compute_bead_version() {
+    local bead_hash="$1"
+
+    if [ -z "$bead_hash" ]; then
+        return 0
+    fi
+
+    printf '%s\n' "${bead_hash:0:12}"
+}
+
+persist_session_metadata() {
+    local worktree_path="$1"
+    local session_id="$2"
+    local project="$3"
+    local prompt="$4"
+    local bead_path="$5"
+    local work_item_key="$6"
+    local model="$7"
+    local bead_spec_hash="$8"
+    local bead_spec_version="$9"
+    local qa_config="${10}"
+
+    local session_file="$worktree_path/.ralphito-session.json"
+
+    python3 - <<'PY' "$session_file" "$session_id" "$project" "$prompt" "$bead_path" "$work_item_key" "$model" "$bead_spec_hash" "$bead_spec_version" "$qa_config"
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+(
+    session_file,
+    session_id,
+    project,
+    prompt,
+    bead_path,
+    work_item_key,
+    model,
+    bead_spec_hash,
+    bead_spec_version,
+    qa_config_raw,
+) = sys.argv[1:]
+
+payload = {
+    'sessionId': session_id,
+    'project': project,
+    'model': model or None,
+    'prompt': prompt,
+    'beadPath': bead_path or None,
+    'workItemKey': work_item_key or None,
+    'beadSpecHash': bead_spec_hash or None,
+    'beadSpecVersion': bead_spec_version or None,
+    'qaConfig': json.loads(qa_config_raw) if qa_config_raw else None,
+    'updatedAt': datetime.now(timezone.utc).isoformat(),
+}
+
+if os.path.exists(session_file):
+    try:
+        with open(session_file, encoding='utf-8') as handle:
+            existing = json.load(handle)
+        if isinstance(existing, dict):
+            existing.update({key: value for key, value in payload.items() if value is not None or key == 'qaConfig'})
+            payload = existing
+    except Exception:
+        pass
+
+with open(session_file, 'w', encoding='utf-8') as handle:
+    json.dump(payload, handle, indent=2)
+    handle.write('\n')
+PY
+}
+
+parse_args() {
+    PROJECT=""
+    PROMPT=""
+    BEAD_PATH=""
+    WORK_ITEM_KEY=""
+    MODEL=""
+    QA_CONFIG=""
+    PAYLOAD_FILE=""
+
+    if [ "${1:-}" = "--payload-file" ]; then
+        PAYLOAD_FILE="${2:-}"
+
+        if [ -z "$PAYLOAD_FILE" ] || [ ! -f "$PAYLOAD_FILE" ]; then
+            printf '{"status":"error","message":"Falta un payload valido para --payload-file."}\n'
+            exit 1
+        fi
+
+        PROJECT="$(extract_payload_field "$PAYLOAD_FILE" project)"
+        PROMPT="$(extract_payload_field "$PAYLOAD_FILE" prompt)"
+        BEAD_PATH="$(extract_payload_field "$PAYLOAD_FILE" beadPath)"
+        WORK_ITEM_KEY="$(extract_payload_field "$PAYLOAD_FILE" workItemKey)"
+        MODEL="$(extract_payload_field "$PAYLOAD_FILE" model)"
+        QA_CONFIG="$(extract_payload_field "$PAYLOAD_FILE" qaConfig)"
+    else
+        PROJECT="${1:-}"
+        PROMPT="${2:-}"
+    fi
+
+    if [ -z "$PROJECT" ] || [ -z "$PROMPT" ]; then
+        printf '{"status":"error","message":"Faltan argumentos. Uso: tool_spawn_executor.sh <proyecto> <prompt_o_spec_path> o --payload-file <ruta.json>"}\n'
+        exit 1
+    fi
+
+    if [ -z "$BEAD_PATH" ]; then
+        BEAD_PATH=$(printf '%s' "$PROMPT" | python3 -c 'import re,sys; match=re.search(r"docs/specs/[^\s]*bead[^\s]*\.md", sys.stdin.read()); print(match.group(0) if match else "")')
+    fi
+}
+
+acquire_lock_if_needed() {
+    local bead_file=""
+    local write_globs=""
+    local normalized_globs=""
+
+    if [ -z "$BEAD_PATH" ]; then
+        return 0
+    fi
+
+    bead_file="$REPO_ROOT/$BEAD_PATH"
+    if [ ! -f "$bead_file" ]; then
+        return 0
+    fi
+
+    write_globs=$(python3 - <<'PY' "$bead_file"
+import re
+import sys
+
+with open(sys.argv[1], encoding='utf-8') as handle:
+    content = handle.read()
+
+match = re.search(r'^\[WRITE_ONLY_GLOBS\]:\s*(.+)$', content, re.MULTILINE)
+print(match.group(1).strip() if match else '')
+PY
+)
+
+    if [ -z "$write_globs" ]; then
+        return 0
+    fi
+
+    normalized_globs=$(printf '%s' "$write_globs" | tr -d ' []"')
+
+    if [ -f "$LOCKS_FILE" ] && grep -Fq "\"lock\": \"$normalized_globs\"" "$LOCKS_FILE"; then
+        local collision_message
+        collision_message="MUTEX COLLISION: Otro Ralphito ya esta editando $normalized_globs. Pon este bead en cola y lanza otro distinto."
+        printf '{"status":"error","message":%s}\n' "$(printf '%s' "$collision_message" | json_escape)"
+        exit 1
+    fi
+
+    python3 - <<'PY' "$LOCKS_FILE" "$normalized_globs" "$BEAD_PATH"
+import json
+import sys
+
+lock_file, normalized_globs, bead_path = sys.argv[1:]
+with open(lock_file, 'a', encoding='utf-8') as handle:
+    handle.write(json.dumps({'lock': normalized_globs, 'bead': bead_path}) + '\n')
+PY
+}
+
+main() {
+    parse_args "$@"
+    acquire_lock_if_needed
+
+    local bead_file=""
+    local bead_spec_hash=""
+    local bead_spec_version=""
+    local spawn_log="/tmp/spawn_output_$$.log"
+    local send_log="/tmp/send_output_$$.log"
+    local session_id=""
+    local worktree_path=""
+    local metadata_warning=""
+
+    if [ -n "$BEAD_PATH" ]; then
+        bead_file="$REPO_ROOT/$BEAD_PATH"
+        bead_spec_hash="$(compute_bead_hash "$bead_file")"
+        bead_spec_version="$(compute_bead_version "$bead_spec_hash")"
+    fi
+
+    echo "🚀 Spawned Ralphito para el proyecto: $PROJECT" >&2
+    echo "Instruccion: $PROMPT" >&2
+
+    if ao spawn "$PROJECT" > "$spawn_log" 2>&1; then
+        session_id=$(python3 - <<'PY' "$spawn_log"
+import sys
+
+session_id = ''
+with open(sys.argv[1], encoding='utf-8') as handle:
+    for line in handle:
+        if line.startswith('SESSION='):
+            session_id = line.strip().split('=', 1)[1]
 
 print(session_id)
 PY
 )
-    if [ -z "$SESSION_ID" ]; then
-        printf '{"status":"error","message":"AO creó una sesión pero no devolvió SESSION=. Revisa tool_check_status."}\n'
-    elif ao send "$SESSION_ID" "$PROMPT" > "$SEND_LOG" 2>&1; then
-        printf '{"status":"success","session_id":"%s","message":"Ralphito iniciado correctamente y prompt enviado. Usa tool_check_status para ver su progreso."}\n' "$SESSION_ID"
+
+        if [ -z "$session_id" ]; then
+            printf '{"status":"error","message":"AO creo una sesion pero no devolvio SESSION=. Revisa tool_check_status."}\n'
+            rm -f "$spawn_log" "$send_log"
+            exit 1
+        fi
+
+        if ! ao send "$session_id" "$PROMPT" > "$send_log" 2>&1; then
+            local error
+            error=$(tr '\n' ' ' < "$send_log")
+            printf '{"status":"error","session_id":"%s","message":"Se creo la sesion pero fallo el envio del prompt.","details":%s}\n' "$session_id" "$(printf '%s' "$error" | json_escape)"
+            rm -f "$spawn_log" "$send_log"
+            exit 1
+        fi
+
+        worktree_path=$(wait_for_ao_worktree "$session_id" 20 || true)
+        if [ -n "$worktree_path" ]; then
+            persist_session_metadata "$worktree_path" "$session_id" "$PROJECT" "$PROMPT" "$BEAD_PATH" "$WORK_ITEM_KEY" "$MODEL" "$bead_spec_hash" "$bead_spec_version" "$QA_CONFIG"
+        else
+            metadata_warning=' La sesion arranco, pero no pude persistir metadata porque el worktree no aparecio a tiempo.'
+        fi
+
+        printf '{"status":"success","session_id":"%s","message":"Ralphito iniciado correctamente y prompt enviado.%s Usa tool_check_status para ver su progreso.","model":%s,"bead_spec_hash":%s,"bead_spec_version":%s}\n' \
+            "$session_id" \
+            "$metadata_warning" \
+            "$(printf '%s' "$MODEL" | json_escape)" \
+            "$(printf '%s' "$bead_spec_hash" | json_escape)" \
+            "$(printf '%s' "$bead_spec_version" | json_escape)"
     else
-        ERROR=$(tr '\n' ' ' < "$SEND_LOG")
-        ESCAPED_ERROR=$(printf '%s' "$ERROR" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-        printf '{"status":"error","session_id":"%s","message":"Se creó la sesión pero falló el envío del prompt: ","details":%s}\n' "$SESSION_ID" "$ESCAPED_ERROR"
+        local error
+        error=$(tr '\n' ' ' < "$spawn_log")
+        printf '{"status":"error","message":%s}\n' "$(printf '%s' "$error" | json_escape)"
+        rm -f "$spawn_log" "$send_log"
+        exit 1
     fi
-else
-    ERROR=$(tr '\n' ' ' < "$SPAWN_LOG")
-    ESCAPED_ERROR=$(printf '%s' "$ERROR" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
-    printf '{"status":"error","message":%s}\n' "$ESCAPED_ERROR"
-fi
-rm -f "$SPAWN_LOG" "$SEND_LOG"
+
+    rm -f "$spawn_log" "$send_log"
+}
+
+main "$@"

--- a/src/features/ao/aoSessionAdapter.ts
+++ b/src/features/ao/aoSessionAdapter.ts
@@ -6,9 +6,10 @@ import * as yaml from 'yaml';
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_DASHBOARD_URL = 'http://127.0.0.1:3000';
-const DEFAULT_TIMEOUT_MS = 4000;
+const DEFAULT_TIMEOUT_MS = 15_000;
 const TERMINAL_STATUSES = new Set(['killed', 'done', 'terminated', 'merged', 'cleanup']);
 const TERMINAL_ACTIVITIES = new Set(['exited']);
+const WORKTREE_ROOT = path.join(process.env.HOME || '', '.worktrees');
 
 interface DashboardApiSession {
   id: string;
@@ -57,7 +58,7 @@ export interface AoStructuredSession {
   createdAt: string | null;
   lastActivityAt: string | null;
   lastActivityLabel: string | null;
-  source: 'dashboard_api' | 'ao_status_json';
+  source: 'dashboard_api' | 'ao_status_json' | 'tmux_fallback';
 }
 
 function getDashboardBaseUrl() {
@@ -158,11 +159,68 @@ async function fetchAoStatusSessions(projectId?: string): Promise<AoStructuredSe
   }));
 }
 
+function readProjectFromWorktree(sessionId: string) {
+  if (!WORKTREE_ROOT || !fs.existsSync(WORKTREE_ROOT)) return null;
+
+  try {
+    for (const projectId of fs.readdirSync(WORKTREE_ROOT)) {
+      const candidate = path.join(WORKTREE_ROOT, projectId, sessionId);
+      if (fs.existsSync(candidate)) return projectId;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function fetchTmuxFallbackSessions(projectId?: string): Promise<AoStructuredSession[]> {
+  const format = ['#{session_name}', '#{session_created}', '#{session_activity}', '#{session_attached}'].join('\t');
+  const { stdout } = await execFileAsync('tmux', ['list-sessions', '-F', format], {
+    timeout: DEFAULT_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  });
+
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [sessionName, createdAt, lastActivityAt, attached] = line.split('\t') as [string, string, string, string];
+      const inferredProjectId = readProjectFromWorktree(sessionName) || null;
+
+      return {
+        id: sessionName,
+        projectId: inferredProjectId,
+        role: 'worker' as const,
+        status: attached === '1' ? 'running' : 'idle',
+        activity: 'tmux',
+        branch: inferredProjectId ? `session/${sessionName}` : null,
+        summary: 'Fallback desde tmux; revisar dashboard/AO si falta metadata.',
+        issue: null,
+        prUrl: null,
+        createdAt: createdAt ? new Date(Number(createdAt) * 1000).toISOString() : null,
+        lastActivityAt: lastActivityAt ? new Date(Number(lastActivityAt) * 1000).toISOString() : null,
+        lastActivityLabel: 'tmux fallback',
+        source: 'tmux_fallback' as const,
+      } satisfies AoStructuredSession;
+    })
+    .filter((session) => !projectId || session.projectId === projectId);
+}
+
 export async function getAoStructuredSessions(projectId?: string) {
   const dashboardSessions = await fetchDashboardSessions(projectId);
   if (dashboardSessions) return dashboardSessions;
 
-  return fetchAoStatusSessions(projectId);
+  try {
+    return await fetchAoStatusSessions(projectId);
+  } catch {
+    try {
+      return await fetchTmuxFallbackSessions(projectId);
+    } catch {
+      return [];
+    }
+  }
 }
 
 export function isActiveAoSession(session: AoStructuredSession) {

--- a/src/features/dashboard/dashboardService.ts
+++ b/src/features/dashboard/dashboardService.ts
@@ -66,7 +66,7 @@ export interface UnifiedDashboardSession {
   createdAt: string | null;
   lastActivityAt: string | null;
   lastActivityLabel: string | null;
-  source: 'dashboard_api' | 'ao_status_json';
+  source: 'dashboard_api' | 'ao_status_json' | 'tmux_fallback';
   thread: {
     id: number;
     channel: string;

--- a/src/features/llm-gateway/tools/telegram-demo/index.ts
+++ b/src/features/llm-gateway/tools/telegram-demo/index.ts
@@ -1,2 +1,2 @@
-export { writeEvidenceTool } from './writeEvidenceTool';
-export type { WriteEvidenceResult } from './writeEvidenceTool';
+export { writeEvidenceTool } from './writeEvidenceTool.js';
+export type { WriteEvidenceResult } from './writeEvidenceTool.js';

--- a/src/features/llm-gateway/tools/toolRegistry.ts
+++ b/src/features/llm-gateway/tools/toolRegistry.ts
@@ -1,4 +1,4 @@
-import { writeEvidenceTool } from './telegram-demo';
+import { writeEvidenceTool } from './telegram-demo/index.js';
 
 export interface Tool {
   name: string;


### PR DESCRIPTION
## Summary
- search AO worktrees in both the legacy runtime path and the managed `~/.worktrees/<project>/<session>` layout, and reuse that lookup in status checks
- extend `tool_spawn_executor.sh` to accept structured payloads, compute bead metadata, and persist `.ralphito-session.json` into the spawned worktree after the session appears
- raise AO status timeouts, add a tmux fallback for status reporting, and align related dashboard/tooling types and imports

## Testing
- `npm ci`
- `npx tsc --noEmit`
- `bash -n scripts/tools/tool_spawn_executor.sh && bash -n scripts/lib/ao-paths.sh && bash -n scripts/tools/tool_check_status.sh && bash -n scripts/resume.sh`
- `bash -lc 'source "scripts/lib/ao-paths.sh" && find_ao_worktree be-49'`
- `npx tsx scripts/ao-status.ts table`
- `./scripts/tools/tool_check_status.sh`

## Related Issue
Refs #12