### PR TITLE
feat(telegram): route bot execution through coordinator loop

### DIFF
--- a/src/features/telegram/bot.ts
+++ b/src/features/telegram/bot.ts
@@ -3,7 +3,8 @@ import * as dotenv from 'dotenv';
 import { analyzeAgentMentions, extractMultiAgentInstruction, loadAgentRegistry, getAgentById, type AgentInfo } from './agentRegistry.js';
 import * as convStore from './conversationStore.js';
 import { executeAgentTask } from './chatExecutor.js';
-import { executeOrchestrationTask, isExplicitExecutionIntent } from './orchestrationExecutor.js';
+import { isExplicitExecutionIntent } from './orchestrationExecutor.js';
+import { runAutonomousCoordinatorLoop } from './ingress/autonomousCoordinatorLoop.js';
 import { initializeRalphitoDatabase } from '../persistence/db/index.js';
 
 // Capturar errores no manejados para ver el error real y no "[Object: null prototype]"
@@ -192,10 +193,7 @@ async function processAgentRequest(ctx: Context, agent: AgentInfo, instruction: 
 
     try {
         if (shouldExecute) {
-            const result = await executeOrchestrationTask(agent.id, instruction);
-            if (result.sessionId) {
-                convStore.setConversationSessionId(chatKey, agent.id, result.sessionId);
-            }
+            const result = await runAutonomousCoordinatorLoop(instruction, chatKey);
             await publishAgentReply(chatId, statusMessage.message_id, agent, result.response);
             return;
         }
@@ -210,7 +208,9 @@ async function processAgentRequest(ctx: Context, agent: AgentInfo, instruction: 
             chatId,
             statusMessage.message_id,
             undefined,
-            `❌ ${agent.name}: ${normalizeErrorMessage(error)}`
+            shouldExecute
+                ? `⚠️ ${agent.name}: Estoy temporalmente degradado. No he podido completar la ejecucion. Intentalo de nuevo en unos segundos.`
+                : `❌ ${agent.name}: ${normalizeErrorMessage(error)}`
         );
     } finally {
         processingChats.delete(chatKey);

--- a/src/features/telegram/ingress/autonomousCoordinatorLoop.ts
+++ b/src/features/telegram/ingress/autonomousCoordinatorLoop.ts
@@ -1,0 +1,145 @@
+interface CoordinatorLike {
+  execute(intent: string, chatId: string): Promise<unknown>;
+}
+
+interface TelegramIngressResult {
+  response: string;
+}
+
+const COORDINATOR_MODULE_PATHS = [
+  '../orchestration/autonomousCoordinator.js',
+  '../orchestration/AutonomousCoordinator.js',
+  '../orchestration/index.js',
+];
+
+function isCoordinatorLike(value: unknown): value is CoordinatorLike {
+  return typeof value === 'object' && value !== null && typeof (value as CoordinatorLike).execute === 'function';
+}
+
+function isConstructor(value: unknown): value is new () => CoordinatorLike {
+  return typeof value === 'function';
+}
+
+function extractCoordinator(moduleRecord: Record<string, unknown>) {
+  const directCandidates = [
+    moduleRecord.autonomousCoordinator,
+    moduleRecord.default,
+  ];
+
+  for (const candidate of directCandidates) {
+    if (isCoordinatorLike(candidate)) return candidate;
+  }
+
+  const constructorCandidates = [
+    moduleRecord.AutonomousCoordinator,
+    moduleRecord.default,
+  ];
+
+  for (const candidate of constructorCandidates) {
+    if (!isConstructor(candidate)) continue;
+
+    try {
+      const instance = new candidate();
+      if (isCoordinatorLike(instance)) return instance;
+    } catch {
+      continue;
+    }
+  }
+
+  if (typeof moduleRecord.getAutonomousCoordinator === 'function') {
+    const coordinator = (moduleRecord.getAutonomousCoordinator as () => unknown)();
+    if (isCoordinatorLike(coordinator)) return coordinator;
+  }
+
+  return null;
+}
+
+async function loadAutonomousCoordinator() {
+  for (const modulePath of COORDINATOR_MODULE_PATHS) {
+    try {
+      const imported = await import(modulePath);
+      const coordinator = extractCoordinator(imported as Record<string, unknown>);
+
+      if (coordinator) return coordinator;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error || '');
+      if (message.includes('Cannot find module') || message.includes('ERR_MODULE_NOT_FOUND')) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw new Error('AutonomousCoordinator is not available in src/features/telegram/orchestration.');
+}
+
+function coerceMessage(value: Record<string, unknown>) {
+  const candidates = [value.message, value.response, value.text, value.finalMessage];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return '';
+}
+
+function coerceEvidencePath(value: Record<string, unknown>) {
+  const candidates = [
+    value.evidencePath,
+    value.relativeEvidencePath,
+    value.artifactPath,
+    value.path,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
+  }
+
+  return '';
+}
+
+function buildTelegramReply(result: Record<string, unknown>) {
+  const message = coerceMessage(result) || 'La ejecucion termino sin devolver un mensaje util.';
+  const evidencePath = coerceEvidencePath(result);
+  const status = typeof result.status === 'string' ? result.status.toLowerCase() : undefined;
+  const success = typeof result.success === 'boolean' ? result.success : undefined;
+
+  if (!evidencePath) {
+    return {
+      response: `${message}\nRuta de evidencia: no disponible`,
+      status: status === 'success' || success === true ? 'controlled_error' : 'controlled_error',
+    } as const;
+  }
+
+  if (status === 'error' || status === 'failed' || success === false) {
+    return {
+      response: `${message}\nRuta de evidencia: ${evidencePath}`,
+      status: 'controlled_error',
+    } as const;
+  }
+
+  return {
+    response: `${message}\nRuta de evidencia: ${evidencePath}`,
+    status: 'success',
+  } as const;
+}
+
+export async function runAutonomousCoordinatorLoop(intent: string, chatId: string): Promise<TelegramIngressResult> {
+  const coordinator = await loadAutonomousCoordinator();
+  const result = await coordinator.execute(intent, chatId);
+
+  if (typeof result !== 'object' || result === null) {
+    return {
+      response: 'La ejecucion termino, pero el coordinador devolvio un formato invalido.\nRuta de evidencia: no disponible',
+    };
+  }
+
+  return {
+    response: buildTelegramReply(result as Record<string, unknown>).response,
+  };
+}


### PR DESCRIPTION
## Summary
- route explicit Telegram execution intents through a dedicated ingress adapter that loads the autonomous coordinator contract
- format coordinator outcomes so replies always include the result text and relative evidence path before Telegram I/O publishes them
- degrade safely with a generic execution message when unexpected coordinator failures occur

## Testing
- `./node_modules/.bin/tsc --noEmit --module nodenext --moduleResolution nodenext --target esnext --strict --types node --skipLibCheck src/features/telegram/ingress/autonomousCoordinatorLoop.ts src/features/telegram/bot.ts`
- `node --import tsx -e "import('./src/features/telegram/ingress/autonomousCoordinatorLoop.ts').then(() => console.log('ingress-ok'))"`
- `./node_modules/.bin/tsc --noEmit` *(currently fails on pre-existing extension issues in `src/features/llm-gateway/tools/telegram-demo/index.ts` and `src/features/llm-gateway/tools/toolRegistry.ts`)*

Closes #18
Related to #12