### PR TITLE
chore(docs): add Gemini entrypoint and git workflow

### DIFF
--- a/.agent-rules.md
+++ b/.agent-rules.md
@@ -58,3 +58,20 @@ Use these rules before claiming status on any bead, issue or project.
 8. **Product tests must use real modules** - If a test redefines coordinators, loggers or ingress locally, treat it as a harness reference, not as true end-to-end validation.
 9. **Project status uses standard buckets** - Report project state with the buckets `master | ramas | local | faltante` whenever there is integration ambiguity.
 10. **Use conservative wording under uncertainty** - Prefer `parcial`, `reutilizable`, `no aterrizado`, or `pendiente de integracion` until git + spec confirm closure.
+
+## Git Workflow (Interactive & Human Sessions)
+
+For interactive work on the main workspace, this workflow is mandatory.
+
+1. **Protect `master`** - `master` is read-only for code changes. Before editing code, run `git branch --show-current`. If the branch is `master`, create a new branch first (`feat/<name>` or `fix/<name>`).
+2. **Use selective staging** - Do not use `git add .` blindly when the worktree contains unrelated changes. Stage only the files that belong to the current task.
+3. **Finish the whole landing cycle** - For interactive work, "done" means all of the following:
+   - local validation passes (for example `npx tsc --noEmit`)
+   - local commit exists
+   - branch is pushed (`./scripts/bd.sh sync` is allowed and preferred when applicable)
+   - pull request is created
+   - pull request is merged to `master`
+   - local workspace is updated with `git checkout master && git pull origin master && git fetch --prune`
+4. **Do not claim completion before merge** - Work that is still only local or only on a branch is not complete.
+
+Exception: AO executors working inside isolated worktrees can keep using their own lifecycle and close with `bd sync`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,14 @@ Este repo combina producto, operacion de agentes y automatizacion local para el 
 - Una bead solo se considera cerrada cuando la spec canonica, la ruta esperada del codigo, la integracion y la validacion ya estan alineadas
 - Las ramas laterales no son verdad canonica por defecto; cada una debe terminar `merged`, `descartada` o `pendiente de port`
 
+## Git Workflow Interactivo
+
+- En sesiones interactivas humanas, `master` es de solo lectura para cambios de codigo; antes de editar, comprobar `git branch --show-current` y crear rama si estas en `master`
+- Prohibido usar `git add .` a ciegas cuando haya multiples cambios en el worktree; usar siempre staging selectivo de los archivos del scope actual
+- En trabajo interactivo, terminar significa completar el ciclo entero: validacion local, commit, push, PR, merge a `master`, actualizar `master` local y `git fetch --prune`
+- Mientras un cambio siga solo en rama o sin mergear, no se declara como trabajo completo
+- Los ejecutores lanzados via AO pueden seguir cerrando con `bd sync` dentro de sus worktrees aislados; esta excepcion no aplica a sesiones humanas sobre el workspace principal
+
 ## Equipos AO
 
 - `backend-team`: implementacion backend y producto general

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,11 @@
+# Gemini Instructions
+
+This repository uses `AGENTS.md` as the canonical global instruction file.
+
+Before starting work:
+
+1. Read `AGENTS.md`.
+2. Read `agents/routing.md` if the task needs repo routing.
+3. For execution, git workflow, and session closure, apply `.agent-rules.md`.
+
+If there is any ambiguity, `AGENTS.md` and `.agent-rules.md` take precedence.


### PR DESCRIPTION
Adds `GEMINI.md` as a CLI entrypoint and documents the interactive git workflow in `AGENTS.md` and `.agent-rules.md` so the multi-CLI agent flow stays aligned.