### PR TITLE
fix: repair telegram live final integration wiring

### DIFF
--- a/src/features/llm-gateway/tools/telegram-demo/index.ts
+++ b/src/features/llm-gateway/tools/telegram-demo/index.ts
@@ -1,2 +1,2 @@
-export { writeEvidenceTool } from './writeEvidenceTool';
-export type { WriteEvidenceResult } from './writeEvidenceTool';
+export { writeEvidenceTool } from './writeEvidenceTool.js';
+export type { WriteEvidenceResult } from './writeEvidenceTool.js';

--- a/src/features/llm-gateway/tools/toolRegistry.ts
+++ b/src/features/llm-gateway/tools/toolRegistry.ts
@@ -1,9 +1,21 @@
-import { writeEvidenceTool } from './telegram-demo';
+import { writeEvidenceTool } from './telegram-demo/index.js';
 
 export interface Tool {
   name: string;
   description: string;
   execute: (params: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface ToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolCallResult {
+  content: string;
+  metadata?: Record<string, unknown>;
+  ok: boolean;
 }
 
 const tools: Tool[] = [
@@ -23,4 +35,35 @@ export function getTools(): Tool[] {
 
 export function getToolByName(name: string): Tool | undefined {
   return tools.find((tool) => tool.name === name);
+}
+
+export async function executeToolCall(toolCall: ToolCall): Promise<ToolCallResult> {
+  const tool = getToolByName(toolCall.name);
+
+  if (!tool) {
+    return {
+      content: `Tool not found: ${toolCall.name}`,
+      ok: false,
+    };
+  }
+
+  try {
+    const result = await tool.execute(toolCall.arguments);
+    const metadata = isRecord(result) ? result : undefined;
+
+    return {
+      content: typeof result === 'string' ? result : JSON.stringify(result),
+      ...(metadata ? { metadata } : {}),
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      content: error instanceof Error ? error.message : 'Unknown tool execution failure',
+      ok: false,
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/src/features/telegram/orchestrationExecutor.ts
+++ b/src/features/telegram/orchestrationExecutor.ts
@@ -9,6 +9,41 @@ export interface OrchestrationResult {
   sessionId?: string;
 }
 
+export type OrchestrationIntent = 'chat' | 'divergence' | 'execution' | 'status';
+
+export function classifyIntent(_agentId: string, instruction: string): OrchestrationIntent {
+  const normalized = instruction.trim().toLowerCase();
+
+  const statusPatterns = [
+    /\bestado\b/i,
+    /\bstatus\b/i,
+    /\bcomo va\b/i,
+    /\bprogreso\b/i,
+    /\bseguimiento\b/i,
+  ];
+
+  const divergencePatterns = [
+    /\bdivergencia\b/i,
+    /\bdiverge\b/i,
+    /\bdesv[ií]ate\b/i,
+    /\bmodo divergente\b/i,
+  ];
+
+  if (statusPatterns.some((pattern) => pattern.test(normalized))) {
+    return 'status';
+  }
+
+  if (divergencePatterns.some((pattern) => pattern.test(normalized))) {
+    return 'divergence';
+  }
+
+  if (isExplicitExecutionIntent(instruction)) {
+    return 'execution';
+  }
+
+  return 'chat';
+}
+
 export function isExplicitExecutionIntent(instruction: string) {
   const normalized = instruction.trim().toLowerCase();
 


### PR DESCRIPTION
Repairs the broken master integration for telegram-live-final by restoring the missing tool registry execution contract, fixing NodeNext exports, and adding the intent classifier expected by the Telegram bot. Typecheck and live-flow E2E now pass.