### PR TITLE
fix(telegram): flexibiliza isExplicitExecutionIntent para mejor UX

### DIFF
--- a/src/features/telegram/orchestrationExecutor.ts
+++ b/src/features/telegram/orchestrationExecutor.ts
@@ -53,6 +53,7 @@ export function isExplicitExecutionIntent(instruction: string) {
   const executionPatterns = [
     /^(ejecuta|ejecutar|programa)\b.*\bbead\b/i,
     /^(orquesta|lanza|ejecuta)\b.*\b(código|script|implementación)\b/i,
+    /^(genera|crea|escribe|guarda)\b.*\b(evidencia|archivo|log)\b/i,
   ];
 
   return hasBeadOrSpec || executionPatterns.some((pattern) => pattern.test(normalized));


### PR DESCRIPTION
## Summary
- Añade patrón `/^(genera|crea|escribe|guarda)\b.*\b(evidencia|archivo|log)\b/i` a `isExplicitExecutionIntent`
- Permite que mensajes naturales como "Raymon, genera evidencia del flujo live" activen el AutonomousCoordinator en lugar de caer a chat

## Testing
- Validado con `npx tsc --noEmit`
- Flujo E2E live verificado en issue #29