### PR TITLE
feat(ux): implement proactive telegram notifications for AO sessions

### DIFF
--- a/scripts/bd.sh
+++ b/scripts/bd.sh
@@ -138,6 +138,93 @@ record_guardrail_failure() {
     printf '%s\n' "$message" | tee -a "$(guardrail_log_path)"
 }
 
+get_session_id() {
+    if [ -f "$REPO_ROOT/.ralphito-session.json" ]; then
+        jq -r '.sessionId' "$REPO_ROOT/.ralphito-session.json" 2>/dev/null || echo ""
+    else
+        echo ""
+    fi
+}
+
+notify_guardrail_failure() {
+    local guardrail_name="$1"
+
+    if [ ! -f "$REPO_ROOT/scripts/notify_telegram.sh" ]; then
+        return
+    fi
+
+    local session_id
+    session_id="$(get_session_id)"
+
+    if [ -z "$session_id" ]; then
+        return
+    fi
+
+    require_cmd node
+
+    local session_info
+    session_info="$(node "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/scripts/ralphito-db.ts" get-session-chat "$session_id" 2>/dev/null)" || return
+
+    local chat_id bead_id has_error error_message
+    chat_id="$(echo "$session_info" | jq -r '.externalChatId' 2>/dev/null)" || return
+    bead_id="$(echo "$session_info" | jq -r '.beadId' 2>/dev/null)" || return
+    has_error="$(echo "$session_info" | jq -r '.hasGuardrailError' 2>/dev/null)" || return
+    error_message="$(echo "$session_info" | jq -r '.guardrailError' 2>/dev/null)" || return
+
+    if [ "$chat_id" = "null" ] || [ -z "$chat_id" ]; then
+        return
+    fi
+
+    local display_bead="UNKNOWN"
+    if [ "$bead_id" != "null" ] && [ -n "$bead_id" ]; then
+        display_bead="$bead_id"
+    fi
+
+    local message
+    if [ "$has_error" = "true" ] && [ "$error_message" != "null" ] && [ -n "$error_message" ]; then
+        message="❌ [${display_bead}] Fallo en ${guardrail_name}. Error: ${error_message}"
+    else
+        message="❌ [${display_bead}] Fallo en ${guardrail_name}."
+    fi
+
+    "$REPO_ROOT/scripts/notify_telegram.sh" "$message" "$chat_id" || true
+}
+
+notify_session_success() {
+    if [ ! -f "$REPO_ROOT/scripts/notify_telegram.sh" ]; then
+        return
+    fi
+
+    local session_id
+    session_id="$(get_session_id)"
+
+    if [ -z "$session_id" ]; then
+        return
+    fi
+
+    require_cmd node
+
+    local session_info
+    session_info="$(node "$REPO_ROOT/node_modules/.bin/tsx" "$REPO_ROOT/scripts/ralphito-db.ts" get-session-chat "$session_id" 2>/dev/null)" || return
+
+    local chat_id bead_id
+    chat_id="$(echo "$session_info" | jq -r '.externalChatId' 2>/dev/null)" || return
+    bead_id="$(echo "$session_info" | jq -r '.beadId' 2>/dev/null)" || return
+
+    if [ "$chat_id" = "null" ] || [ -z "$chat_id" ]; then
+        return
+    fi
+
+    local display_bead="UNKNOWN"
+    if [ "$bead_id" != "null" ] && [ -n "$bead_id" ]; then
+        display_bead="$bead_id"
+    fi
+
+    local message="✅ [${display_bead}] Tarea completada y aterrizada en master."
+
+    "$REPO_ROOT/scripts/notify_telegram.sh" "$message" "$chat_id" || true
+}
+
 has_package_json() {
     [ -f "$REPO_ROOT/package.json" ]
 }
@@ -174,11 +261,13 @@ collect_modified_files() {
 run_guardrail() {
     local start_message="$1"
     local failure_message="$2"
-    shift 2
+    local guardrail_name="$3"
+    shift 3
 
     info "$start_message"
     "$@" > "$(guardrail_log_path)" 2>&1 || {
         record_guardrail_failure "$failure_message"
+        notify_guardrail_failure "$guardrail_name"
         exit 1
     }
 }
@@ -258,12 +347,12 @@ case "$COMMAND" in
 
             if [ -f "$REPO_ROOT/tsconfig.json" ]; then
                 require_cmd npx
-                run_guardrail "⚡ Running tsc --noEmit..." "❌ Guardrail failed: TypeScript type errors found." npx tsc --noEmit
+                run_guardrail "⚡ Running tsc --noEmit..." "❌ Guardrail failed: TypeScript type errors found." "TypeScript" npx tsc --noEmit
             fi
 
             if has_npm_script lint; then
                 require_cmd npm
-                run_guardrail "🧹 Running linter..." "❌ Guardrail failed: Linter errors found." npm run lint
+                run_guardrail "🧹 Running linter..." "❌ Guardrail failed: Linter errors found." "ESLint" npm run lint
             fi
 
             if has_npm_script test; then
@@ -271,7 +360,7 @@ case "$COMMAND" in
                 if is_placeholder_test_script; then
                     info "⏭️ Skipping placeholder test script in package.json."
                 else
-                    run_guardrail "🧪 Running tests..." "❌ Guardrail failed: Tests failed." npm test
+                    run_guardrail "🧪 Running tests..." "❌ Guardrail failed: Tests failed." "Tests" npm test
                 fi
             fi
         fi
@@ -294,9 +383,7 @@ case "$COMMAND" in
 
         info "✅ Sync complete. Work safely landed."
 
-        if [ -f "$REPO_ROOT/scripts/notify_telegram.sh" ]; then
-            "$REPO_ROOT/scripts/notify_telegram.sh" "✅ Un agente terminó su tarea (Sync exitoso en rama $(current_branch))" || true
-        fi
+        notify_session_success
 
         info "💀 Phase 3: Terminating agent session to release resources..."
         if [ -n "${TMUX:-}" ]; then

--- a/scripts/notify_telegram.sh
+++ b/scripts/notify_telegram.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Uso: ./notify_telegram.sh "Mensaje que quieres enviar"
+# Uso: ./notify_telegram.sh "Mensaje que quieres enviar" [chat_id]
+# Si chat_id no se pasa, usa TELEGRAM_ALLOWED_CHAT_ID del .env
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -10,20 +11,21 @@ if [ -f "$REPO_ROOT/.env" ]; then
 fi
 
 MESSAGE="$1"
+CHAT_ID="${2:-${TELEGRAM_ALLOWED_CHAT_ID}}"
 
 if [ -z "$MESSAGE" ]; then
     echo "Error: Se requiere un mensaje."
     exit 1
 fi
 
-if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_ALLOWED_CHAT_ID" ]; then
-    echo "Aviso: TELEGRAM_BOT_TOKEN o TELEGRAM_ALLOWED_CHAT_ID no configurados. No se enviará notificación."
+if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$CHAT_ID" ]; then
+    echo "Aviso: TELEGRAM_BOT_TOKEN o CHAT_ID no configurados. No se enviará notificación."
     exit 0
 fi
 
 # Hacer la petición a la API de Telegram usando curl
 RESPONSE=$(curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-    -d "chat_id=${TELEGRAM_ALLOWED_CHAT_ID}" \
+    -d "chat_id=${CHAT_ID}" \
     -d "text=${MESSAGE}" \
     -d "parse_mode=HTML")
 

--- a/scripts/ralphito-db.ts
+++ b/scripts/ralphito-db.ts
@@ -1,27 +1,111 @@
 #!/usr/bin/env node
 
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
 import { getRalphitoDatabase, initializeRalphitoDatabase } from '../src/features/persistence/db/index.js';
+
+const AO_DATA_DIR = process.env.AO_DATA_DIR || path.join(process.env.HOME || '', '.agent-orchestrator');
+
+interface SessionChatResult {
+  externalChatId: string | null;
+  beadId: string | null;
+  title: string | null;
+  hasGuardrailError: boolean;
+  guardrailError: string | null;
+}
+
+function truncateError(errorText: string): string {
+  const normalized = errorText.trim();
+  if (normalized.length <= 700) return normalized;
+  return `${normalized.slice(0, 697)}...`;
+}
+
+function getGuardrailErrorForSession(sessionId: string): string | null {
+  try {
+    const orchestratorDirs = readdirSync(AO_DATA_DIR, { withFileTypes: true }).filter((entry) => entry.isDirectory());
+
+    for (const dir of orchestratorDirs) {
+      const errorPath = path.join(AO_DATA_DIR, dir.name, 'worktrees', sessionId, '.guardrail_error.log');
+      try {
+        return truncateError(readFileSync(errorPath, 'utf8'));
+      } catch {
+        // continue
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function runGetSessionChat(sessionId: string) {
+  initializeRalphitoDatabase();
+  const db = getRalphitoDatabase();
+
+  const thread = db
+    .prepare(
+      `
+        SELECT threads.external_chat_id AS externalChatId
+        FROM agent_sessions
+        INNER JOIN threads ON threads.id = agent_sessions.thread_id
+        WHERE agent_sessions.ao_session_id = ?
+        LIMIT 1
+      `,
+    )
+    .get(sessionId) as { externalChatId: string } | undefined;
+
+  const task = db
+    .prepare(
+      `
+        SELECT id, title
+        FROM tasks
+        WHERE ao_session_id = ?
+        ORDER BY updated_at DESC
+        LIMIT 1
+      `,
+    )
+    .get(sessionId) as { id: string; title: string } | undefined;
+
+  const guardrailError = getGuardrailErrorForSession(sessionId);
+
+  const result: SessionChatResult = {
+    externalChatId: thread?.externalChatId ?? null,
+    beadId: task?.id ?? null,
+    title: task?.title ?? null,
+    hasGuardrailError: guardrailError !== null,
+    guardrailError,
+  };
+
+  console.log(JSON.stringify(result));
+}
 
 const command = process.argv[2] || 'migrate';
 
-function runMigrate() {
-  initializeRalphitoDatabase();
-  const db = getRalphitoDatabase();
-  const migrations = db
-    .prepare('SELECT id, name, applied_at AS appliedAt FROM ralphito_migrations ORDER BY id ASC')
-    .all() as Array<{ id: number; name: string; appliedAt: string }>;
-
-  console.log('Ralphito SQLite ready. Applied migrations:');
-
-  for (const migration of migrations) {
-    console.log(`- ${migration.id}: ${migration.name} (${migration.appliedAt})`);
-  }
-}
-
 switch (command) {
-  case 'migrate':
-    runMigrate();
+  case 'migrate': {
+    initializeRalphitoDatabase();
+    const db = getRalphitoDatabase();
+    const migrations = db
+      .prepare('SELECT id, name, applied_at AS appliedAt FROM ralphito_migrations ORDER BY id ASC')
+      .all() as Array<{ id: number; name: string; appliedAt: string }>;
+
+    console.log('Ralphito SQLite ready. Applied migrations:');
+
+    for (const migration of migrations) {
+      console.log(`- ${migration.id}: ${migration.name} (${migration.appliedAt})`);
+    }
     break;
+  }
+  case 'get-session-chat': {
+    const sessionId = process.argv[3];
+    if (!sessionId) {
+      console.error('Usage: ralphito-db.ts get-session-chat <sessionId>');
+      process.exit(1);
+    }
+    runGetSessionChat(sessionId);
+    break;
+  }
   default:
     console.error(`Unknown command: ${command}`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Add `get-session-chat` command to `ralphito-db.ts` for querying session metadata from SQLite
- Update `notify_telegram.sh` to accept optional `chat_id` parameter (backwards compatible)
- Add `notify_guardrail_failure()` and `notify_session_success()` to `bd.sh`
- Integrate notifications at 3 guardrail failure points + 1 success point

## Messages
- Fallo: `❌ [be-XX] Fallo en TypeScript/ESLint/Tests. Error: <log>`
- Éxito: `✅ [be-XX] Tarea completada y aterrizada en master.`