### PR TITLE
feat(ao): inject HEAD hash as --base-ref in spawn executor

### DIFF
--- a/scripts/tools/tool_spawn_executor.sh
+++ b/scripts/tools/tool_spawn_executor.sh
@@ -51,7 +51,9 @@ echo "Instrucción: $PROMPT" >&2
 SPAWN_LOG="/tmp/spawn_output_$$.log"
 SEND_LOG="/tmp/send_output_$$.log"
 
-if ao spawn "$PROJECT" > "$SPAWN_LOG" 2>&1; then
+CURRENT_COMMIT_HASH=$(git -C "$REPO_ROOT" rev-parse HEAD)
+
+if ao spawn "$PROJECT" --base-ref "$CURRENT_COMMIT_HASH" > "$SPAWN_LOG" 2>&1; then
     SESSION_ID=$(python3 - <<'PY' "$SPAWN_LOG"
 import sys
 


### PR DESCRIPTION
## Summary
- Capture `HEAD` commit hash before spawning agent via `git -C "$REPO_ROOT" rev-parse HEAD`
- Pass `--base-ref "$CURRENT_COMMIT_HASH"` to `ao spawn` for immutable session context
- Ensures agent starts from exact code snapshot, eliminating branch drift

## Changes
- `scripts/tools/tool_spawn_executor.sh`: Inject HEAD hash capture and `--base-ref` flag

## Validation
- `bash -n scripts/tools/tool_spawn_executor.sh`: SYNTAX OK