### PR TITLE
feat(sqlite): track base_commit_hash on agent sessions for immutable spawn traceability

### DIFF
--- a/scripts/tools/tool_spawn_executor.sh
+++ b/scripts/tools/tool_spawn_executor.sh
@@ -69,7 +69,7 @@ PY
     if [ -z "$SESSION_ID" ]; then
         printf '{"status":"error","message":"AO creó una sesión pero no devolvió SESSION=. Revisa tool_check_status."}\n'
     elif ao send "$SESSION_ID" "$PROMPT" > "$SEND_LOG" 2>&1; then
-        printf '{"status":"success","session_id":"%s","message":"Ralphito iniciado correctamente y prompt enviado. Usa tool_check_status para ver su progreso."}\n' "$SESSION_ID"
+        printf '{"status":"success","session_id":"%s","base_commit_hash":"%s","message":"Ralphito iniciado correctamente y prompt enviado. Usa tool_check_status para ver su progreso."}\n' "$SESSION_ID" "$CURRENT_COMMIT_HASH"
     else
         ERROR=$(tr '\n' ' ' < "$SEND_LOG")
         ESCAPED_ERROR=$(printf '%s' "$ERROR" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')

--- a/src/features/ao/spawnExecutorClient.ts
+++ b/src/features/ao/spawnExecutorClient.ts
@@ -62,6 +62,7 @@ export interface SpawnExecutorResult {
   status?: string;
   message?: string;
   session_id?: string;
+  base_commit_hash?: string;
   details?: string;
   model?: string;
   bead_spec_hash?: string;

--- a/src/features/persistence/db/migrations.ts
+++ b/src/features/persistence/db/migrations.ts
@@ -198,4 +198,11 @@ export const ralphitoMigrations: RalphitoMigration[] = [
         ON system_events(event_type, created_at DESC);
     `,
   },
+  {
+    id: 9,
+    name: 'add_base_commit_hash_to_agent_sessions',
+    sql: `
+      ALTER TABLE agent_sessions ADD COLUMN base_commit_hash TEXT;
+    `,
+  },
 ];

--- a/src/features/persistence/db/repositories.ts
+++ b/src/features/persistence/db/repositories.ts
@@ -29,6 +29,7 @@ export interface UpsertAgentSessionInput {
   agentId: string;
   aoSessionId: string;
   status: string;
+  baseCommitHash?: string;
 }
 
 export interface CreateTaskInput {
@@ -152,12 +153,13 @@ class AgentSessionsRepository {
     this.db
       .prepare(
         `
-          INSERT INTO agent_sessions (thread_id, agent_id, ao_session_id, status, created_at, updated_at)
-          VALUES (@threadId, @agentId, @aoSessionId, @status, @now, @now)
+          INSERT INTO agent_sessions (thread_id, agent_id, ao_session_id, status, base_commit_hash, created_at, updated_at)
+          VALUES (@threadId, @agentId, @aoSessionId, @status, @baseCommitHash, @now, @now)
           ON CONFLICT(thread_id, agent_id)
           DO UPDATE SET
             ao_session_id = excluded.ao_session_id,
             status = excluded.status,
+            base_commit_hash = COALESCE(excluded.base_commit_hash, base_commit_hash),
             updated_at = excluded.updated_at
         `,
       )

--- a/src/features/telegram/bot.ts
+++ b/src/features/telegram/bot.ts
@@ -214,7 +214,7 @@ async function processAgentRequest(ctx: Context, agent: AgentInfo, instruction: 
         if (shouldExecute) {
             const result = await executeOrchestrationTask(agent.id, instruction);
             if (result.sessionId) {
-                convStore.setConversationSessionId(chatKey, agent.id, result.sessionId);
+                convStore.setConversationSessionId(chatKey, agent.id, result.sessionId, result.baseCommitHash);
             }
             await publishAgentReply(chatId, statusMessage.message_id, agent, result.response);
             return;

--- a/src/features/telegram/conversationStore.ts
+++ b/src/features/telegram/conversationStore.ts
@@ -8,8 +8,8 @@ export function getConversationSessionId(chatId: string, agentId: string) {
   return getRepository().getConversationSessionId(chatId, agentId);
 }
 
-export function setConversationSessionId(chatId: string, agentId: string, sessionId: string) {
-  getRepository().setConversationSessionId(chatId, agentId, sessionId);
+export function setConversationSessionId(chatId: string, agentId: string, sessionId: string, baseCommitHash?: string) {
+  getRepository().setConversationSessionId(chatId, agentId, sessionId, baseCommitHash);
 }
 
 export function setMessageAgentRoute(chatId: string, messageId: number, agentId: string) {

--- a/src/features/telegram/orchestrationExecutor.ts
+++ b/src/features/telegram/orchestrationExecutor.ts
@@ -7,6 +7,7 @@ const ORCHESTRATOR_PROJECT_ID = 'backend-team';
 export interface OrchestrationResult {
   response: string;
   sessionId?: string;
+  baseCommitHash?: string;
 }
 
 export type OrchestrationIntent = 'chat' | 'divergence' | 'execution' | 'status';
@@ -75,6 +76,7 @@ export async function executeOrchestrationTask(agentId: string, instruction: str
         status?: string;
         message?: string;
         session_id?: string;
+        base_commit_hash?: string;
         details?: string;
       };
 
@@ -87,6 +89,7 @@ export async function executeOrchestrationTask(agentId: string, instruction: str
       const sessionInfo = result.session_id ? ` He abierto la sesión ${result.session_id}.` : '';
       return {
         ...(result.session_id ? { sessionId: result.session_id } : {}),
+        ...(result.base_commit_hash ? { baseCommitHash: result.base_commit_hash } : {}),
         response: `Lo pongo en marcha.${sessionInfo} ${result.message || 'Puedes seguir el progreso por estado cuando quieras.'}`.trim(),
       };
     } catch (parseError) {

--- a/src/features/telegram/persistence/sessionRepository.ts
+++ b/src/features/telegram/persistence/sessionRepository.ts
@@ -3,7 +3,7 @@ import { getTelegramStateRepository } from '../telegramStateRepository.js';
 
 export interface SessionRepository {
   getConversationSessionId(chatId: string, agentId: string): string | null;
-  setConversationSessionId(chatId: string, agentId: string, sessionId: string, updatedAt?: string): void;
+  setConversationSessionId(chatId: string, agentId: string, sessionId: string, baseCommitHash?: string, updatedAt?: string): void;
   setMessageAgentRoute(chatId: string, messageId: number, agentId: string, updatedAt?: string): void;
   getAgentRouteForMessage(chatId: string, messageId: number): string | null;
   setActiveAgent(chatId: string, agentId: string, updatedAt?: string): void;
@@ -21,8 +21,8 @@ export class SQLiteSessionRepository implements SessionRepository {
     return this.repository.getConversationSessionId(chatId, agentId);
   }
 
-  setConversationSessionId(chatId: string, agentId: string, sessionId: string, updatedAt?: string) {
-    this.repository.setConversationSessionId(chatId, agentId, sessionId, updatedAt);
+  setConversationSessionId(chatId: string, agentId: string, sessionId: string, baseCommitHash?: string, updatedAt?: string) {
+    this.repository.setConversationSessionId(chatId, agentId, sessionId, baseCommitHash, updatedAt);
   }
 
   setMessageAgentRoute(chatId: string, messageId: number, agentId: string, updatedAt?: string) {

--- a/src/features/telegram/telegramStateRepository.ts
+++ b/src/features/telegram/telegramStateRepository.ts
@@ -169,23 +169,24 @@ export class TelegramStateRepository {
     return row?.aoSessionId || null;
   }
 
-  setConversationSessionId(chatId: string, agentId: string, sessionId: string, updatedAt?: string) {
+  setConversationSessionId(chatId: string, agentId: string, sessionId: string, baseCommitHash?: string, updatedAt?: string) {
     const threadId = this.ensureThread(chatId);
     const timestamp = updatedAt || new Date().toISOString();
 
     this.db
       .prepare(
         `
-          INSERT INTO agent_sessions (thread_id, agent_id, ao_session_id, status, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?)
+          INSERT INTO agent_sessions (thread_id, agent_id, ao_session_id, status, base_commit_hash, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(thread_id, agent_id)
           DO UPDATE SET
             ao_session_id = excluded.ao_session_id,
             status = excluded.status,
+            base_commit_hash = COALESCE(excluded.base_commit_hash, base_commit_hash),
             updated_at = excluded.updated_at
         `,
       )
-      .run(threadId, agentId, sessionId, 'bound', timestamp, timestamp);
+      .run(threadId, agentId, sessionId, 'bound', baseCommitHash || null, timestamp, timestamp);
   }
 
   setMessageAgentRoute(chatId: string, messageId: number, agentId: string, updatedAt?: string) {


### PR DESCRIPTION
## Summary
- Capture `base_commit_hash` when spawning agents and persist to SQLite
- Full propagation chain: tool_spawn_executor.sh → OrchestrationResult → bot.ts → conversationStore → telegramStateRepository → SQLite
- Retrocompatible: column is NULLable, COALESCE on upsert preserves existing values

## Changes
- `scripts/tools/tool_spawn_executor.sh`: Include `base_commit_hash` in JSON response
- `src/features/ao/spawnExecutorClient.ts`: Add `base_commit_hash` to `SpawnExecutorResult`
- `src/features/telegram/orchestrationExecutor.ts`: Extract and propagate `base_commit_hash`
- `src/features/telegram/bot.ts`: Pass `baseCommitHash` to `setConversationSessionId`
- `src/features/telegram/conversationStore.ts`: Accept optional `baseCommitHash` param
- `src/features/telegram/persistence/sessionRepository.ts`: Interface and implementation update
- `src/features/telegram/telegramStateRepository.ts`: Store `base_commit_hash` in INSERT/UPDATE
- `src/features/persistence/db/repositories.ts`: Add `baseCommitHash` to `UpsertAgentSessionInput` and INSERT
- `src/features/persistence/db/migrations.ts`: Migration 9 to add column

## Validation
- Typecheck: PASSED
- Script syntax: OK
- Migration 9 applied successfully