### PR TITLE
fix: qa lifecycle cleanup

### DIFF
--- a/scripts/e2e-qa.ts
+++ b/scripts/e2e-qa.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import { spawn, type ChildProcess } from 'child_process';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { chromium } from 'playwright';
 import type { QAConfig } from '../src/features/ao/spawnExecutorClient.js';
+import { startDevServer, stopDevServer, waitForReady, type DevServerHandle } from './lib/dev-server.js';
 
 interface E2EReportRoute {
   route: string;
@@ -104,34 +104,6 @@ function buildEvidenceDir(session: SessionState, qaConfig: QAConfig | null | und
   return path.join(root, session.sessionId || 'unknown-session', new Date().toISOString().replace(/[:.]/g, '-'));
 }
 
-async function startServer(command: string, cwd: string, evidenceDir: string) {
-  const serverLogPath = path.join(evidenceDir, 'server.log');
-  const output = fs.createWriteStream(serverLogPath, { flags: 'a' });
-  const child = spawn(command, {
-    cwd,
-    shell: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, CI: process.env.CI || '1' },
-  });
-  child.stdout?.pipe(output);
-  child.stderr?.pipe(output);
-  return child;
-}
-
-async function waitForUrl(url: string) {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < DEFAULT_TIMEOUT_MS) {
-    try {
-      const response = await fetch(url, { method: 'GET' });
-      if (response.ok) return;
-    } catch {
-      // retry
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-  throw new Error(`Timeout esperando readiness en ${url}`);
-}
-
 function normalizeRoute(route: string) {
   if (!route) return '/';
   return route.startsWith('/') ? route : `/${route}`;
@@ -227,13 +199,6 @@ function summarizeStatus(routes: E2EReportRoute[]) {
   return 'passed' as const;
 }
 
-async function stopServer(child: ChildProcess | null) {
-  if (!child || child.killed) return;
-  child.kill('SIGTERM');
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  if (!child.killed) child.kill('SIGKILL');
-}
-
 async function writeReport(report: E2EReport, evidenceDir?: string) {
   if (!evidenceDir) return;
   await writeFile(path.join(evidenceDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
@@ -268,17 +233,26 @@ async function main() {
 
   const evidenceDir = buildEvidenceDir(session, qaConfig);
   await mkdir(evidenceDir, { recursive: true });
-  let child: ChildProcess | null = null;
+  let server: DevServerHandle | null = null;
   let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
   let startedServer = false;
+  let exitCode = 0;
 
   try {
     if (qaConfig.devServerCommand && !noServer) {
-      child = await startServer(qaConfig.devServerCommand, repoRoot, evidenceDir);
+      server = await startDevServer({
+        command: qaConfig.devServerCommand,
+        cwd: repoRoot,
+        logPath: path.join(evidenceDir, 'server.log'),
+      });
       startedServer = true;
     }
 
-    await waitForUrl(qaConfig.healthcheckUrl || qaConfig.baseUrl);
+    await waitForReady({
+      url: qaConfig.healthcheckUrl || qaConfig.baseUrl,
+      server,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    });
     browser = await chromium.launch({ headless: true });
     const routeReports: E2EReportRoute[] = [];
     for (const route of routes) {
@@ -311,7 +285,7 @@ async function main() {
       routeCount: routeReports.length,
     });
     console.log(JSON.stringify(report));
-    if (!effectiveShadowMode && status === 'failed') process.exit(1);
+    if (!effectiveShadowMode && status === 'failed') exitCode = 1;
   } catch (error) {
     const generatedAt = new Date().toISOString();
     const reason = error instanceof Error ? error.message : String(error);
@@ -341,14 +315,18 @@ async function main() {
       routeCount: 0,
     });
     console.log(JSON.stringify(report));
-    if (!effectiveShadowMode) process.exit(1);
+    if (!effectiveShadowMode) exitCode = 1;
   } finally {
     await browser?.close();
-    await stopServer(child);
+    await stopDevServer(server);
+  }
+
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
   }
 }
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/lib/dev-server.ts
+++ b/scripts/lib/dev-server.ts
@@ -1,0 +1,179 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { once } from 'events';
+import * as fs from 'fs';
+
+const DEFAULT_READY_TIMEOUT_MS = 60_000;
+const DEFAULT_READY_INTERVAL_MS = 1_000;
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+export interface StartDevServerOptions {
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  logPath?: string;
+  mirrorOutput?: boolean;
+}
+
+export interface WaitForReadyOptions {
+  url: string;
+  server?: DevServerHandle | null;
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+export interface StopDevServerOptions {
+  graceTimeoutMs?: number;
+  forceTimeoutMs?: number;
+}
+
+export interface DevServerHandle {
+  child: ChildProcessWithoutNullStreams;
+  logPath?: string;
+  logStream?: fs.WriteStream;
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForChildClose(child: ChildProcessWithoutNullStreams, timeoutMs: number) {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+
+  try {
+    await Promise.race([
+      once(child, 'close'),
+      delay(timeoutMs).then(() => {
+        throw new Error('timeout');
+      }),
+    ]);
+    return true;
+  } catch {
+    return child.exitCode !== null || child.signalCode !== null;
+  }
+}
+
+function describeChildExit(child: ChildProcessWithoutNullStreams) {
+  return `exitCode=${child.exitCode ?? 'null'} signal=${child.signalCode ?? 'null'}`;
+}
+
+function sendSignalToServerTree(child: ChildProcessWithoutNullStreams, signal: NodeJS.Signals) {
+  if (!child.pid) return;
+
+  if (process.platform === 'win32') {
+    child.kill(signal);
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return;
+    child.kill(signal);
+  }
+}
+
+async function closeLogStream(logStream?: fs.WriteStream) {
+  if (!logStream || logStream.closed) return;
+
+  await new Promise<void>((resolve, reject) => {
+    logStream.once('error', reject);
+    logStream.once('close', () => resolve());
+    logStream.end();
+  }).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_STREAM_DESTROYED') {
+      throw error;
+    }
+  });
+}
+
+export async function startDevServer(options: StartDevServerOptions): Promise<DevServerHandle> {
+  const { command, cwd, env, logPath, mirrorOutput = false } = options;
+  const logStream = logPath ? fs.createWriteStream(logPath, { flags: 'a' }) : undefined;
+
+  const child = spawn(command, {
+    cwd,
+    shell: true,
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      ...env,
+      CI: env?.CI ?? process.env.CI ?? '1',
+    },
+  });
+
+  if (logStream) {
+    child.stdout.pipe(logStream);
+    child.stderr.pipe(logStream);
+  }
+
+  if (mirrorOutput) {
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+  }
+
+  return {
+    child,
+    ...(logPath ? { logPath } : {}),
+    ...(logStream ? { logStream } : {}),
+  };
+}
+
+export async function waitForReady(options: WaitForReadyOptions) {
+  const {
+    url,
+    server,
+    timeoutMs = DEFAULT_READY_TIMEOUT_MS,
+    intervalMs = DEFAULT_READY_INTERVAL_MS,
+  } = options;
+  const startedAt = Date.now();
+  let lastError = '';
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (server?.child && (server.child.exitCode !== null || server.child.signalCode !== null)) {
+      throw new Error(`Dev server salio antes del readiness: ${describeChildExit(server.child)}`);
+    }
+
+    try {
+      const response = await fetch(url, { method: 'GET' });
+      if (response.ok) return;
+      lastError = `readiness devolvio ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    await delay(intervalMs);
+  }
+
+  throw new Error(`Timeout esperando readiness en ${url}${lastError ? ` (${lastError})` : ''}`);
+}
+
+export async function stopDevServer(server: DevServerHandle | null, options: StopDevServerOptions = {}) {
+  if (!server) return;
+
+  const { child, logStream } = server;
+  const graceTimeoutMs = options.graceTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+  const forceTimeoutMs = options.forceTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+
+  try {
+    if (child.exitCode === null && child.signalCode === null) {
+      sendSignalToServerTree(child, 'SIGTERM');
+      const exitedGracefully = await waitForChildClose(child, graceTimeoutMs);
+
+      if (!exitedGracefully && child.exitCode === null && child.signalCode === null) {
+        sendSignalToServerTree(child, 'SIGKILL');
+        const exitedForcefully = await waitForChildClose(child, forceTimeoutMs);
+        if (!exitedForcefully) {
+          throw new Error(`No pude parar el dev server pid=${child.pid ?? 'unknown'}`);
+        }
+      }
+    }
+  } finally {
+    child.stdout.unpipe();
+    child.stderr.unpipe();
+    child.stdout.destroy();
+    child.stderr.destroy();
+    await closeLogStream(logStream);
+  }
+}

--- a/scripts/qa-pipeline-smoke.ts
+++ b/scripts/qa-pipeline-smoke.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { execFile, spawn, type ChildProcess } from 'child_process';
+import { execFile } from 'child_process';
 import { copyFile, readFile, rm, writeFile } from 'fs/promises';
 import fs from 'fs';
 import path from 'path';
 import * as util from 'util';
 import type { QAConfig } from '../src/features/ao/spawnExecutorClient.js';
+import { startDevServer, stopDevServer, waitForReady, type DevServerHandle } from './lib/dev-server.js';
 
 const execFileAsync = util.promisify(execFile);
 const repoRoot = process.cwd();
@@ -109,33 +110,23 @@ async function readFinalSession() {
   return JSON.parse(await readFile(sessionPath, 'utf8')) as Record<string, unknown>;
 }
 
-async function waitForHealthcheck(url: string, timeoutMs = 30_000) {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const res = await fetch(url);
-      if (res.ok) return;
-    } catch { /* retry */ }
-    await new Promise(r => setTimeout(r, 1000));
-  }
-  throw new Error(`Healthcheck timeout: ${url}`);
-}
-
 async function main() {
   await backupExistingSession();
 
-  let child: ChildProcess | null = null;
+  let server: DevServerHandle | null = null;
 
   try {
-    child = spawn('npx', ['tsx', 'scripts/qa-fixture-server.ts'], {
+    server = await startDevServer({
+      command: 'npx tsx scripts/qa-fixture-server.ts',
       cwd: repoRoot,
-      shell: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      mirrorOutput: true,
     });
-    child.stdout?.pipe(process.stdout);
-    child.stderr?.pipe(process.stderr);
 
-    await waitForHealthcheck(qaConfig.healthcheckUrl!);
+    await waitForReady({
+      url: qaConfig.healthcheckUrl!,
+      server,
+      timeoutMs: 30_000,
+    });
 
     await writeFixtureSession();
 
@@ -151,16 +142,12 @@ async function main() {
       e2eQa: finalSession['e2eQa'] || null,
     }, null, 2));
   } finally {
-    if (child && !child.killed) {
-      child.kill('SIGTERM');
-      await new Promise(r => setTimeout(r, 500));
-      if (!child.killed) child.kill('SIGKILL');
-    }
+    await stopDevServer(server);
     await restoreExistingSession();
   }
 }
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/visual-qa.ts
+++ b/scripts/visual-qa.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { spawn, type ChildProcess } from 'child_process';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import fs from 'fs';
 import os from 'os';
@@ -8,6 +7,7 @@ import path from 'path';
 import { chromium } from 'playwright';
 import { ProviderFactory } from '../src/features/llm-gateway/providers/provider.factory.js';
 import type { QAConfig } from '../src/features/ao/spawnExecutorClient.js';
+import { startDevServer, stopDevServer, waitForReady, type DevServerHandle } from './lib/dev-server.js';
 
 interface SessionState {
   sessionId: string;
@@ -117,42 +117,6 @@ function buildEvidenceDir(session: SessionState, qaConfig: QAConfig | null | und
   const sessionId = session.sessionId || 'unknown-session';
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   return path.join(root, sessionId, timestamp);
-}
-
-async function startServer(command: string, cwd: string, evidenceDir: string) {
-  const serverLogPath = path.join(evidenceDir, 'server.log');
-  const output = fs.createWriteStream(serverLogPath, { flags: 'a' });
-  const child = spawn(command, {
-    cwd,
-    shell: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    env: {
-      ...process.env,
-      CI: process.env.CI || '1',
-    },
-  });
-
-  child.stdout?.pipe(output);
-  child.stderr?.pipe(output);
-
-  return { child, serverLogPath };
-}
-
-async function waitForUrl(url: string) {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < DEFAULT_TIMEOUT_MS) {
-    try {
-      const response = await fetch(url, { method: 'GET' });
-      if (response.ok) return;
-    } catch {
-      // Keep polling until timeout.
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-
-  throw new Error(`Timeout esperando readiness en ${url}`);
 }
 
 function normalizeRoute(route: string) {
@@ -306,15 +270,6 @@ async function writeReport(report: VisualQAReport, evidenceDir?: string) {
   await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
 }
 
-async function stopServer(child: ChildProcess | null) {
-  if (!child || child.killed) return;
-  child.kill('SIGTERM');
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  if (!child.killed) {
-    child.kill('SIGKILL');
-  }
-}
-
 async function main() {
   const { repoRoot, shadow, noServer } = parseArgs();
   const session = await loadSessionState(repoRoot);
@@ -345,18 +300,26 @@ async function main() {
   const evidenceDir = buildEvidenceDir(session, qaConfig);
   await mkdir(evidenceDir, { recursive: true });
 
-  let child: ChildProcess | null = null;
+  let server: DevServerHandle | null = null;
   let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null;
   let startedServer = false;
+  let exitCode = 0;
 
   try {
     if (qaConfig.devServerCommand && !noServer) {
-      const server = await startServer(qaConfig.devServerCommand, repoRoot, evidenceDir);
-      child = server.child;
+      server = await startDevServer({
+        command: qaConfig.devServerCommand,
+        cwd: repoRoot,
+        logPath: path.join(evidenceDir, 'server.log'),
+      });
       startedServer = true;
     }
 
-    await waitForUrl(qaConfig.healthcheckUrl || qaConfig.baseUrl);
+    await waitForReady({
+      url: qaConfig.healthcheckUrl || qaConfig.baseUrl,
+      server,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+    });
     browser = await chromium.launch({ headless: true });
 
     const routes: RouteEvidence[] = [];
@@ -411,7 +374,7 @@ async function main() {
     console.log(JSON.stringify(report));
 
     if (!effectiveShadowMode && status === 'failed') {
-      process.exit(1);
+      exitCode = 1;
     }
   } catch (error) {
     const report: VisualQAReport = {
@@ -439,15 +402,19 @@ async function main() {
     console.log(JSON.stringify(report));
 
     if (!effectiveShadowMode) {
-      process.exit(1);
+      exitCode = 1;
     }
   } finally {
     await browser?.close();
-    await stopServer(child);
+    await stopDevServer(server);
+  }
+
+  if (exitCode !== 0) {
+    process.exitCode = exitCode;
   }
 }
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
Closes #46

- add shared dev server helper
- reuse it in e2e, visual, smoke
- defer exit code until cleanup

Validacion
- npx tsc --noEmit
- npx tsx scripts/qa-pipeline-smoke.ts
- e2e no-shadow pass/fail smokes