### PR TITLE
fix: ensure e2e-qa.ts exits cleanly after tests pass

### DIFF
--- a/scripts/e2e-qa.ts
+++ b/scripts/e2e-qa.ts
@@ -321,12 +321,10 @@ async function main() {
     await stopDevServer(server);
   }
 
-  if (exitCode !== 0) {
-    process.exitCode = exitCode;
-  }
+  process.exit(exitCode);
 }
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Fix issue #44: `bd merge` hangs after Ricky (e2e-qa) passes
- The problem was that `e2e-qa.ts` only called `process.exitCode = exitCode` when `exitCode !== 0`, but never actually called `process.exit()`
- When tests passed (`exitCode === 0`), the process would hang waiting for the event loop to drain
- Fixed by calling `process.exit(exitCode)` unconditionally to ensure clean exit in all cases

## Changes
- `scripts/e2e-qa.ts`: Changed from `if (exitCode !== 0) { process.exitCode = exitCode; }` to `process.exit(exitCode)`
- Same fix applied to the `main().catch()` handler

Closes #44