### PR TITLE
fix(runtime): harden outbox delivery

### DIFF
--- a/scripts/engine-status.ts
+++ b/scripts/engine-status.ts
@@ -1,11 +1,23 @@
 #!/usr/bin/env node
 
 import chalk from 'chalk';
-import { formatEngineSessionLine, getEngineSessionsStatus } from '../src/features/engine/status.js';
+import {
+  formatEngineSessionLine,
+  getEngineNotificationRepository,
+  getEngineSessionsStatus,
+} from '../src/features/engine/index.js';
+
+function formatNotificationLine(notification: ReturnType<typeof getEngineNotificationRepository>['listRecent'][number]) {
+  const chat = notification.targetChatId || '-';
+  const sessionId = notification.runtimeSessionId || '-';
+  const errorSuffix = notification.errorMessage ? ` error=${notification.errorMessage}` : '';
+  return `  ${notification.createdAt}  [${notification.status}]  ${notification.eventType}  session=${sessionId}  chat=${chat}  attempts=${notification.attemptCount}${errorSuffix}`;
+}
 
 async function main() {
   const command = process.argv[2] || 'table';
   const sessions = await getEngineSessionsStatus();
+  const notificationRepository = getEngineNotificationRepository();
 
   switch (command) {
     case 'json': {
@@ -25,6 +37,26 @@ async function main() {
       for (const session of sessions) {
         console.log(formatEngineSessionLine(session));
       }
+      return;
+    }
+    case 'notifications': {
+      const notifications = notificationRepository.listRecent(20);
+      if (notifications.length === 0) {
+        console.log(chalk.dim('  (no notifications)'));
+        return;
+      }
+
+      for (const notification of notifications) {
+        console.log(formatNotificationLine(notification));
+      }
+      return;
+    }
+    case 'notifications-json': {
+      console.log(JSON.stringify(notificationRepository.listRecent(20), null, 2));
+      return;
+    }
+    case 'notification-summary': {
+      console.log(JSON.stringify(notificationRepository.getSummary(), null, 2));
       return;
     }
     default:

--- a/scripts/tools/tool_check_status.sh
+++ b/scripts/tools/tool_check_status.sh
@@ -10,8 +10,16 @@ source "$SCRIPT_DIR/../lib/runtime-paths.sh"
 
 # Primero mostramos el estado que conoce Ralphito Engine
 echo "=== STATUS DE SESIONES (RALPHITO ENGINE) ==="
-ENGINE_STATUS=$(npx tsx "$REPO_ROOT/scripts/engine-status.ts" table || echo "")
+ENGINE_STATUS=$(node --import tsx "$REPO_ROOT/scripts/engine-status.ts" table || echo "")
 echo "$ENGINE_STATUS"
+
+echo ""
+echo "=== ENGINE NOTIFICATIONS OUTBOX ==="
+node --import tsx "$REPO_ROOT/scripts/engine-status.ts" notification-summary || true
+
+echo ""
+echo "=== ULTIMAS NOTIFICACIONES ==="
+node --import tsx "$REPO_ROOT/scripts/engine-status.ts" notifications || true
 
 echo ""
 echo "=== BUSCANDO RALPHITOS CAÍDOS (GUARDRAILS FALLIDOS) ==="
@@ -37,7 +45,7 @@ fi
 
 echo ""
 echo "=== AUTOPILOT QUEUE CHECK ==="
-ACTIVE_COUNT=$(npx tsx "$REPO_ROOT/scripts/engine-status.ts" active-count || echo "0")
+ACTIVE_COUNT=$(node --import tsx "$REPO_ROOT/scripts/engine-status.ts" active-count || echo "0")
 
 if [ "$ACTIVE_COUNT" = "0" ]; then
     echo "⚠️ [AUTOPILOT TRIGGER] La fábrica está parada. No hay Ralphitos trabajando."

--- a/src/features/engine/cli.ts
+++ b/src/features/engine/cli.ts
@@ -14,7 +14,11 @@ import { ExecutorLoop } from './executorLoop.js';
 import { getEngineSessionsStatus, formatEngineSessionLine } from './status.js';
 import { resumeRuntimeSession } from './resume.js';
 import { clearRuntimeFailureRecord } from './runtimeFiles.js';
-import { enqueueEngineNotification } from './engineNotifications.js';
+import {
+  enqueueEngineNotification,
+  getEngineNotificationRepository,
+} from './engineNotifications.js';
+import { EngineNotificationDispatcher } from '../telegram/engineNotificationDispatcher.js';
 
 function printJson(payload: unknown) {
   process.stdout.write(`${JSON.stringify(payload)}\n`);
@@ -313,6 +317,40 @@ async function main() {
       return;
     }
 
+    case 'deliver-notifications': {
+      const limitArg = args[0];
+      const limit = limitArg ? Number.parseInt(limitArg, 10) : 20;
+      if (Number.isNaN(limit) || limit <= 0) {
+        throw new Error('Uso: cli.ts deliver-notifications [limit_positivo]');
+      }
+
+      const dispatcher = new EngineNotificationDispatcher();
+      const result = await dispatcher.pollOnce(limit);
+      printJson({ status: 'ok', ...result });
+      return;
+    }
+
+    case 'notification-status': {
+      const format = args[0] || 'summary';
+      const limitArg = args[1];
+      const limit = limitArg ? Number.parseInt(limitArg, 10) : 20;
+      if (Number.isNaN(limit) || limit <= 0) {
+        throw new Error('Uso: cli.ts notification-status [summary|json] [limit_positivo]');
+      }
+
+      const repository = getEngineNotificationRepository();
+      switch (format) {
+        case 'summary':
+          printJson(repository.getSummary());
+          return;
+        case 'json':
+          printJson(repository.listRecent(limit));
+          return;
+        default:
+          throw new Error('Uso: cli.ts notification-status [summary|json] [limit_positivo]');
+      }
+    }
+
     case 'status': {
       const format = args[0] || 'table';
       const sessions = await getEngineSessionsStatus();
@@ -359,6 +397,8 @@ async function main() {
           'cli.ts finish-session <runtime_session_id> [done|cancelled]',
           'cli.ts resume-session <runtime_session_id>',
           'cli.ts enqueue-notification <runtime_session_id|-> <event_type> <payload_json> [target_chat_id]',
+          'cli.ts deliver-notifications [limit_positivo]',
+          'cli.ts notification-status [summary|json] [limit_positivo]',
           'cli.ts status [table|json|active-count]',
         ].join('\n'),
       );

--- a/src/features/engine/engineNotifications.ts
+++ b/src/features/engine/engineNotifications.ts
@@ -1,4 +1,6 @@
+import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
+import { fileURLToPath } from 'url';
 import { getRalphitoDatabase } from '../persistence/db/index.js';
 import {
   DEFAULT_ENGINE_NOTIFICATION_DELIVERY_LEASE_MS,
@@ -94,6 +96,17 @@ export interface EngineNotificationRecord<T extends EngineNotificationEventType 
   errorMessage: string | null;
 }
 
+export interface EngineNotificationSummary {
+  total: number;
+  pending: number;
+  delivering: number;
+  delivered: number;
+  failed: number;
+  pendingWithoutTarget: number;
+  oldestOutstandingAt: string | null;
+  newestCreatedAt: string | null;
+}
+
 export interface EnqueueEngineNotificationInput<T extends EngineNotificationEventType = EngineNotificationEventType> {
   eventId?: string;
   runtimeSessionId?: string | null;
@@ -118,6 +131,17 @@ interface SessionTargetChatRow {
   externalChatId: string | null;
 }
 
+interface NotificationStatusCountRow {
+  status: EngineNotificationStatus;
+  count: number;
+}
+
+interface NotificationTimestampRow {
+  createdAt: string;
+}
+
+const ENGINE_CLI_PATH = fileURLToPath(new URL('./cli.ts', import.meta.url));
+
 function normalizeOptionalText(value: unknown) {
   if (typeof value !== 'string') return null;
   const normalized = value.trim();
@@ -134,6 +158,34 @@ function addMilliseconds(isoTimestamp: string, milliseconds: number) {
 
 function getRetryDelayMs(attemptCount: number) {
   return DEFAULT_ENGINE_NOTIFICATION_RETRY_BASE_MS * 2 ** Math.max(attemptCount - 1, 0);
+}
+
+function shouldKickNotificationDelivery() {
+  if (process.env.RALPHITO_DISABLE_NOTIFICATION_KICK === '1') return false;
+  if (process.env.RALPHITO_NOTIFICATION_DELIVERY_CHILD === '1') return false;
+  return true;
+}
+
+function kickNotificationDelivery() {
+  if (!shouldKickNotificationDelivery()) return;
+
+  try {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', ENGINE_CLI_PATH, 'deliver-notifications', '20'],
+      {
+        detached: true,
+        stdio: 'ignore',
+        env: {
+          ...process.env,
+          RALPHITO_NOTIFICATION_DELIVERY_CHILD: '1',
+        },
+      },
+    );
+    child.unref();
+  } catch {
+    // El poller del bot sigue siendo la red de seguridad.
+  }
 }
 
 function mapNotificationRow(row: Record<string, unknown>) {
@@ -247,6 +299,7 @@ export class EngineNotificationRepository {
         createdAt,
       );
 
+    kickNotificationDelivery();
     return this.getByEventId<T>(eventId);
   }
 
@@ -366,6 +419,106 @@ export class EngineNotificationRepository {
       )
       .all()
       .map((row) => mapNotificationRow(row as Record<string, unknown>));
+  }
+
+  listRecent(limit = 20) {
+    return this.db
+      .prepare(
+        `
+          SELECT
+            event_id AS eventId,
+            runtime_session_id AS runtimeSessionId,
+            event_type AS eventType,
+            payload_json AS payloadJson,
+            target_chat_id AS targetChatId,
+            status,
+            attempt_count AS attemptCount,
+            next_attempt_at AS nextAttemptAt,
+            created_at AS createdAt,
+            delivered_at AS deliveredAt,
+            error_message AS errorMessage
+          FROM engine_notifications
+          ORDER BY created_at DESC, event_id DESC
+          LIMIT ?
+        `,
+      )
+      .all(limit)
+      .map((row) => mapNotificationRow(row as Record<string, unknown>));
+  }
+
+  getSummary() {
+    const counts = new Map<EngineNotificationStatus, number>([
+      ['pending', 0],
+      ['delivering', 0],
+      ['delivered', 0],
+      ['failed', 0],
+    ]);
+
+    const statusRows = this.db
+      .prepare(
+        `
+          SELECT status, COUNT(*) AS count
+          FROM engine_notifications
+          GROUP BY status
+        `,
+      )
+      .all() as NotificationStatusCountRow[];
+
+    for (const row of statusRows) {
+      counts.set(row.status, row.count);
+    }
+
+    const oldestOutstanding = this.db
+      .prepare(
+        `
+          SELECT created_at AS createdAt
+          FROM engine_notifications
+          WHERE status IN ('pending', 'delivering')
+          ORDER BY created_at ASC, event_id ASC
+          LIMIT 1
+        `,
+      )
+      .get() as NotificationTimestampRow | undefined;
+
+    const newestCreated = this.db
+      .prepare(
+        `
+          SELECT created_at AS createdAt
+          FROM engine_notifications
+          ORDER BY created_at DESC, event_id DESC
+          LIMIT 1
+        `,
+      )
+      .get() as NotificationTimestampRow | undefined;
+
+    const pendingWithoutTarget = (
+      this.db
+        .prepare(
+          `
+            SELECT COUNT(*) AS count
+            FROM engine_notifications
+            WHERE status IN ('pending', 'delivering')
+              AND (target_chat_id IS NULL OR TRIM(target_chat_id) = '')
+          `,
+        )
+        .get() as { count: number }
+    ).count;
+
+    const pending = counts.get('pending') || 0;
+    const delivering = counts.get('delivering') || 0;
+    const delivered = counts.get('delivered') || 0;
+    const failed = counts.get('failed') || 0;
+
+    return {
+      total: pending + delivering + delivered + failed,
+      pending,
+      delivering,
+      delivered,
+      failed,
+      pendingWithoutTarget,
+      oldestOutstandingAt: normalizeOptionalText(oldestOutstanding?.createdAt),
+      newestCreatedAt: normalizeOptionalText(newestCreated?.createdAt),
+    } satisfies EngineNotificationSummary;
   }
 }
 

--- a/src/features/engine/index.ts
+++ b/src/features/engine/index.ts
@@ -91,6 +91,7 @@ export {
 export {
   ENGINE_NOTIFICATION_EVENT_TYPES,
   EngineNotificationRepository,
+  type EngineNotificationSummary,
   enqueueEngineNotification,
   getEngineNotificationRepository,
   resetEngineNotificationRepository,

--- a/src/features/engine/runtimePhase3.test.ts
+++ b/src/features/engine/runtimePhase3.test.ts
@@ -72,10 +72,12 @@ function createTempRepo() {
 function withTempRuntime<T>(fn: (ctx: { repoRoot: string; headCommit: string }) => Promise<T> | T) {
   const previousCwd = process.cwd();
   const previousDbPath = process.env.RALPHITO_DB_PATH;
+  const previousDisableKick = process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
   const { repoRoot, headCommit } = createTempRepo();
 
   process.chdir(repoRoot);
   process.env.RALPHITO_DB_PATH = path.join(repoRoot, 'ops', 'runtime', 'ralphito', 'ralphito.sqlite');
+  process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = '1';
   closeRalphitoDatabase();
   resetRuntimeSessionRepository();
   resetRuntimeLockRepository();
@@ -93,6 +95,11 @@ function withTempRuntime<T>(fn: (ctx: { repoRoot: string; headCommit: string }) 
         process.env.RALPHITO_DB_PATH = previousDbPath;
       } else {
         delete process.env.RALPHITO_DB_PATH;
+      }
+      if (previousDisableKick) {
+        process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = previousDisableKick;
+      } else {
+        delete process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
       }
       process.chdir(previousCwd);
       rmSync(repoRoot, { force: true, recursive: true });
@@ -178,6 +185,7 @@ test('SessionSupervisor crea sesion runtime con thread sintetico y session file'
     assert.deepEqual(createdSessions, [result.runtimeSessionId]);
     assert.match(launchCommands[0] || '', /(?:codex --full-auto --no-alt-screen|opencode run "\$RALPHITO_INSTRUCTION")/);
     assert.equal(createdEnvs[0]?.CI, '1');
+    assert.equal(createdEnvs[0]?.RALPHITO_DB_PATH, path.join(repoRoot, 'ops', 'runtime', 'ralphito', 'ralphito.sqlite'));
     assert.equal(detachedCalls.length, 1);
     assert.match(createdEnvs[0]?.RALPHITO_INSTRUCTION || '', /Implementa la fase 3\./);
     assert.match(readFileSync(sessionFilePath, 'utf8'), /"pid": 987/);

--- a/src/features/engine/runtimePhase5.test.ts
+++ b/src/features/engine/runtimePhase5.test.ts
@@ -22,11 +22,13 @@ function withTempRuntime<T>(fn: (repoRoot: string) => Promise<T> | T) {
   const previousCwd = process.cwd();
   const previousDbPath = process.env.RALPHITO_DB_PATH;
   const previousAllowedChatId = process.env.TELEGRAM_ALLOWED_CHAT_ID;
+  const previousDisableKick = process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
   const repoRoot = createTempDirectory('rr-engine-phase5-');
 
   process.chdir(repoRoot);
   process.env.RALPHITO_DB_PATH = path.join(repoRoot, 'ops', 'runtime', 'ralphito', 'ralphito.sqlite');
   process.env.TELEGRAM_ALLOWED_CHAT_ID = 'ops-chat';
+  process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = '1';
   closeRalphitoDatabase();
   resetEngineNotificationRepository();
   initializeRalphitoDatabase();
@@ -45,6 +47,11 @@ function withTempRuntime<T>(fn: (repoRoot: string) => Promise<T> | T) {
         process.env.TELEGRAM_ALLOWED_CHAT_ID = previousAllowedChatId;
       } else {
         delete process.env.TELEGRAM_ALLOWED_CHAT_ID;
+      }
+      if (previousDisableKick) {
+        process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = previousDisableKick;
+      } else {
+        delete process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
       }
       process.chdir(previousCwd);
       rmSync(repoRoot, { force: true, recursive: true });
@@ -123,5 +130,54 @@ test('EngineNotificationDispatcher reintenta y deja failed terminal al agotar in
     assert.equal(notification?.status, 'failed');
     assert.equal(notification?.attemptCount, 5);
     assert.match(notification?.errorMessage || '', /telegram down/);
+  });
+});
+
+test('EngineNotificationRepository resume outbox state para status', async () => {
+  await withTempRuntime(async () => {
+    enqueueEngineNotification({
+      eventType: 'session.started',
+      targetChatId: 'chat-1',
+      payload: {
+        projectId: 'backend-team',
+        branchName: 'jopen/demo',
+        beadPath: null,
+        workItemKey: null,
+      },
+    });
+
+    enqueueEngineNotification({
+      eventType: 'session.spawn_failed',
+      payload: {
+        projectId: 'backend-team',
+        branchName: 'jopen/demo',
+        beadPath: null,
+        workItemKey: null,
+        error: 'boom',
+      },
+    });
+
+    const repository = getEngineNotificationRepository();
+    const [first, second] = repository.listRecent(10).reverse();
+
+    assert.equal(first?.status, 'pending');
+    assert.equal(second?.status, 'pending');
+
+    repository.markDelivered(first!.eventId);
+    repository.markFailed({
+      eventId: second!.eventId,
+      attemptCount: 1,
+      errorMessage: 'No target chat id for engine notification',
+      terminal: true,
+    });
+
+    const summary = repository.getSummary();
+
+    assert.equal(summary.total, 2);
+    assert.equal(summary.pending, 0);
+    assert.equal(summary.delivered, 1);
+    assert.equal(summary.failed, 1);
+    assert.equal(summary.pendingWithoutTarget, 0);
+    assert.ok(summary.newestCreatedAt);
   });
 });

--- a/src/features/engine/sessionSupervisor.ts
+++ b/src/features/engine/sessionSupervisor.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import path from 'path';
+import { getRalphitoDatabasePath } from '../persistence/db/index.js';
 import { getRalphitoDatabase } from '../persistence/db/index.js';
 import { CommandRunner } from './commandRunner.js';
 import { resolveEngineProjectConfig } from './config.js';
@@ -216,6 +217,7 @@ export class SessionSupervisor {
         buildLaunchCommand(project.agent, model),
         toStringEnv(process.env, {
           CI: '1',
+          RALPHITO_DB_PATH: getRalphitoDatabasePath(),
           RALPHITO_RUNTIME_SESSION_ID: runtimeSessionId,
           RALPHITO_ENGINE_MANAGED: '1',
           RALPHITO_PROJECT_ID: project.id,

--- a/src/features/ops/observabilityService.ts
+++ b/src/features/ops/observabilityService.ts
@@ -1,5 +1,6 @@
 import { mkdir } from 'fs/promises';
 import path from 'path';
+import { getEngineNotificationRepository } from '../engine/engineNotifications.js';
 import { getEngineSessionsStatus } from '../engine/status.js';
 import { getRalphitoDatabase, getRalphitoDatabasePath } from '../persistence/db/index.js';
 
@@ -168,6 +169,7 @@ export async function getOperationalStatus() {
 
   const stuckTasks = getStuckTasks();
   const orphanSessions = await getOrphanSessionCount();
+  const notificationSummary = getEngineNotificationRepository().getSummary();
 
   return {
     health: {
@@ -181,6 +183,7 @@ export async function getOperationalStatus() {
       orphanSessions,
       stuckTasks: stuckTasks.length,
       summaries: getSummaryCount(),
+      notificationOutbox: notificationSummary,
     },
     stuckTasks,
     recentEvents: getRecentEvents(),

--- a/src/features/telegram/bot.ts
+++ b/src/features/telegram/bot.ts
@@ -330,10 +330,19 @@ bot.catch((err, ctx) => {
     console.error('↳ Chat:', ctx.chat?.id, 'Update:', ctx.updateType);
 });
 
-bot.launch().then(() => {
+async function startTelegramBot() {
     notificationDispatcher.start();
-    console.log('✅ Bot de Telegram iniciado correctamente.');
-}).catch((err) => {
+
+    try {
+        await bot.launch();
+        console.log('✅ Bot de Telegram iniciado correctamente.');
+    } catch (err) {
+        notificationDispatcher.stop();
+        throw err;
+    }
+}
+
+void startTelegramBot().catch((err) => {
     console.error('❌ Error al iniciar el bot:', err);
 });
 process.once('SIGINT', () => {

--- a/src/features/telegram/engineNotificationDispatcher.ts
+++ b/src/features/telegram/engineNotificationDispatcher.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_ENGINE_NOTIFICATION_MAX_ATTEMPTS,
   DEFAULT_ENGINE_NOTIFICATION_POLL_INTERVAL_MS,
   getEngineNotificationRepository,
+  type EngineNotificationSummary,
   type EngineNotificationRecord,
   type SessionGuardrailFailedNotificationPayload,
   type SessionInteractiveBlockedNotificationPayload,
@@ -12,6 +13,15 @@ import {
   type SessionTimeoutNotificationPayload,
 } from '../engine/index.js';
 import { sendTelegramMessage, type SendTelegramMessageResult } from './telegramSender.js';
+
+export interface EngineNotificationPollResult {
+  scanned: number;
+  claimed: number;
+  delivered: number;
+  failed: number;
+  busy: boolean;
+  summary: EngineNotificationSummary;
+}
 
 function escapeHtml(text: string) {
   return text
@@ -183,9 +193,22 @@ export class EngineNotificationDispatcher {
   start() {
     if (this.timer) return;
 
-    void this.pollOnce();
+    console.log(
+      `[EngineNotificationDispatcher] started interval_ms=${this.pollIntervalMs}`,
+    );
+    void this.pollOnce().catch((error: unknown) => {
+      console.error(
+        '[EngineNotificationDispatcher] initial poll failed:',
+        error instanceof Error ? error.message : String(error),
+      );
+    });
     this.timer = setInterval(() => {
-      void this.pollOnce();
+      void this.pollOnce().catch((error: unknown) => {
+        console.error(
+          '[EngineNotificationDispatcher] interval poll failed:',
+          error instanceof Error ? error.message : String(error),
+        );
+      });
     }, this.pollIntervalMs);
 
     this.timer.unref?.();
@@ -195,21 +218,53 @@ export class EngineNotificationDispatcher {
     if (!this.timer) return;
     clearInterval(this.timer);
     this.timer = null;
+    console.log('[EngineNotificationDispatcher] stopped');
   }
 
   async pollOnce(limit = 20) {
-    if (this.running) return;
+    if (this.running) {
+      return {
+        scanned: 0,
+        claimed: 0,
+        delivered: 0,
+        failed: 0,
+        busy: true,
+        summary: this.repository.getSummary(),
+      } satisfies EngineNotificationPollResult;
+    }
     this.running = true;
+    const result = {
+      scanned: 0,
+      claimed: 0,
+      delivered: 0,
+      failed: 0,
+      busy: false,
+      summary: this.repository.getSummary(),
+    } satisfies EngineNotificationPollResult;
 
     try {
       const nowIso = new Date().toISOString();
       const notifications = this.repository.listDeliverable(nowIso, limit);
+      result.scanned = notifications.length;
 
       for (const notification of notifications) {
         const claimed = this.repository.claim(notification.eventId, nowIso);
         if (!claimed) continue;
-        await this.deliver(claimed);
+        result.claimed += 1;
+        const outcome = await this.deliver(claimed);
+        if (outcome === 'delivered') {
+          result.delivered += 1;
+        } else {
+          result.failed += 1;
+        }
       }
+      result.summary = this.repository.getSummary();
+      if (result.scanned > 0 || result.failed > 0) {
+        console.log(
+          `[EngineNotificationDispatcher] poll scanned=${result.scanned} claimed=${result.claimed} delivered=${result.delivered} failed=${result.failed} pending=${result.summary.pending} delivering=${result.summary.delivering}`,
+        );
+      }
+      return result;
     } finally {
       this.running = false;
     }
@@ -239,13 +294,17 @@ export class EngineNotificationDispatcher {
         failedAt,
         terminal: true,
       });
-      return;
+      console.error(
+        `[EngineNotificationDispatcher] failed event=${notification.eventId} type=${notification.eventType} reason=no_target_chat_id`,
+      );
+      return 'failed' as const;
     }
 
     try {
       const message = formatEngineNotificationMessage(notification);
       await this.send(targetChatId, message);
       this.repository.markDelivered(notification.eventId, new Date().toISOString());
+      return 'delivered' as const;
     } catch (error) {
       const attemptCount = notification.attemptCount + 1;
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -256,6 +315,10 @@ export class EngineNotificationDispatcher {
         failedAt,
         terminal: attemptCount >= DEFAULT_ENGINE_NOTIFICATION_MAX_ATTEMPTS,
       });
+      console.error(
+        `[EngineNotificationDispatcher] failed event=${notification.eventId} type=${notification.eventType} attempt=${attemptCount} error=${errorMessage}`,
+      );
+      return 'failed' as const;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add outbox summary and recent notification visibility to runtime status surfaces
- trigger one-shot delivery when notifications are enqueued and harden dispatcher startup/logging
- export the canonical Ralphito DB path into managed runtime sessions so worktrees write to the same outbox

## Validation
- npx tsc --noEmit
- node --import tsx --test src/features/engine/runtimePhase3.test.ts
- node --import tsx --test src/features/engine/runtimePhase5.test.ts

Refs #72