### PR TITLE
fix(ops): separa salud viva e historico

### DIFF
--- a/docs/runbooks/ralphito-recovery.md
+++ b/docs/runbooks/ralphito-recovery.md
@@ -14,10 +14,13 @@ Campos clave a mirar:
 
 - `health.db.ok`: la base SQLite responde
 - `health.engine.ok`: el engine responde y puede listar sesiones
-- `metrics.failedQueries`: numero de consultas de retrieval/search fallidas
-- `metrics.averageRetrievalMs`: latencia media reciente de retrieval
-- `metrics.orphanSessions`: bindings SQLite -> engine sin sesion viva
-- `metrics.stuckTasks`: tasks abiertas sin movimiento durante la ventana de alerta
+- `current.sessions.active`: sesiones activas segun status actual
+- `current.sessions.alive`: sesiones realmente vivas ahora
+- `current.notificationBacklog.pending`: backlog vivo de notificaciones
+- `historical.retrieval.failedQueries`: fallos recientes de retrieval/search
+- `historical.retrieval.averageRetrievalMs`: latencia media reciente de retrieval
+- `historical.debt.orphanSessions`: bindings SQLite -> engine sin sesion viva
+- `historical.debt.stuckTaskCount`: tasks abiertas sin movimiento durante la ventana de alerta
 
 ## Backups SQLite
 
@@ -41,7 +44,7 @@ Flujo recomendado:
 
 ## Recovery de sesiones huerfanas
 
-Si `metrics.orphanSessions` es mayor que 0:
+Si `historical.debt.orphanSessions` es mayor que 0:
 
 1. Revisar `GET /api/ops/status` o `npm run ops:status`
 2. Confirmar si el engine ya no tiene esas sesiones
@@ -50,9 +53,9 @@ Si `metrics.orphanSessions` es mayor que 0:
 
 ## Recovery de tasks atascadas
 
-Si `metrics.stuckTasks` es mayor que 0:
+Si `historical.debt.stuckTaskCount` es mayor que 0:
 
-1. Revisar los ids expuestos en `stuckTasks`
+1. Revisar los ids expuestos en `historical.debt.stuckTasks`
 2. Abrir el dashboard en `/dashboard`
 3. Pausar (`blocked`) o cancelar (`cancelled`) si la task no puede continuar
 4. Si aplica, reinyectar el error al ejecutor:
@@ -61,11 +64,11 @@ Si `metrics.stuckTasks` es mayor que 0:
 
 ## Fallos de retrieval o search
 
-Si sube `metrics.failedQueries`:
+Si sube `historical.retrieval.failedQueries`:
 
 1. Reindexar documentos con `npm run search:index`
 2. Revalidar con `GET /api/search?q=<consulta>`
-3. Revisar `recentEvents` en `GET /api/ops/status`
+3. Revisar `historical.recentEvents` en `GET /api/ops/status`
 
 ## Cierre
 
@@ -73,5 +76,6 @@ Antes de declarar el sistema sano:
 
 - `health.db.ok = true`
 - `health.engine.ok = true`
-- `metrics.orphanSessions = 0` o explicado
-- `metrics.stuckTasks = 0` o explicado
+- `current.sessions.alive >= current.sessions.active` o explicado
+- `historical.debt.orphanSessions = 0` o explicado
+- `historical.debt.stuckTaskCount = 0` o explicado

--- a/src/features/ops/observabilityService.test.ts
+++ b/src/features/ops/observabilityService.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, rmSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  closeRalphitoDatabase,
+  initializeRalphitoDatabase,
+} from '../persistence/db/index.js';
+import {
+  enqueueEngineNotification,
+  getEngineNotificationRepository,
+  resetEngineNotificationRepository,
+} from '../engine/engineNotifications.js';
+import {
+  getRuntimeSessionRepository,
+  resetRuntimeSessionRepository,
+} from '../engine/runtimeSessionRepository.js';
+import { getOperationalStatus } from './observabilityService.js';
+
+function createTempDirectory(prefix: string) {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function withTempRuntime<T>(fn: () => Promise<T> | T) {
+  const previousCwd = process.cwd();
+  const previousDbPath = process.env.RALPHITO_DB_PATH;
+  const previousDisableKick = process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
+  const repoRoot = createTempDirectory('rr-ops-status-');
+
+  process.chdir(repoRoot);
+  process.env.RALPHITO_DB_PATH = path.join(repoRoot, 'ops', 'runtime', 'ralphito', 'ralphito.sqlite');
+  process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = '1';
+  closeRalphitoDatabase();
+  resetRuntimeSessionRepository();
+  resetEngineNotificationRepository();
+  initializeRalphitoDatabase();
+
+  return Promise.resolve()
+    .then(() => fn())
+    .finally(() => {
+      closeRalphitoDatabase();
+      resetRuntimeSessionRepository();
+      resetEngineNotificationRepository();
+      if (previousDbPath) {
+        process.env.RALPHITO_DB_PATH = previousDbPath;
+      } else {
+        delete process.env.RALPHITO_DB_PATH;
+      }
+      if (previousDisableKick) {
+        process.env.RALPHITO_DISABLE_NOTIFICATION_KICK = previousDisableKick;
+      } else {
+        delete process.env.RALPHITO_DISABLE_NOTIFICATION_KICK;
+      }
+      process.chdir(previousCwd);
+      rmSync(repoRoot, { force: true, recursive: true });
+    });
+}
+
+function insertThread(runtimeSessionId: string, createdAt: string) {
+  const db = initializeRalphitoDatabase();
+  return Number(
+    db
+      .prepare(
+        `
+          INSERT INTO threads (channel, external_chat_id, title, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)
+        `,
+      )
+      .run('runtime', runtimeSessionId, runtimeSessionId, createdAt, createdAt).lastInsertRowid,
+  );
+}
+
+test('getOperationalStatus separa salud viva del historico y deuda operativa', async () => {
+  await withTempRuntime(async () => {
+    const db = initializeRalphitoDatabase();
+    const repository = getRuntimeSessionRepository();
+
+    repository.create({
+      threadId: insertThread('be-orphan', '2026-03-24T10:00:00.000Z'),
+      agentId: 'backend-team',
+      runtimeSessionId: 'be-orphan',
+      status: 'running',
+      startedAt: '2026-03-24T10:00:00.000Z',
+      heartbeatAt: '2026-03-24T10:05:00.000Z',
+      createdAt: '2026-03-24T10:00:00.000Z',
+      updatedAt: '2026-03-24T10:05:00.000Z',
+    });
+
+    db.prepare(
+      `
+        INSERT INTO tasks (
+          id,
+          project_key,
+          title,
+          source_spec_path,
+          component_path,
+          status,
+          assigned_agent,
+          runtime_session_id,
+          priority,
+          created_at,
+          updated_at,
+          completed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      'task-stale',
+      'backend',
+      'Task vieja',
+      null,
+      'src/features/ops',
+      'pending',
+      'backend-team',
+      'be-orphan',
+      'high',
+      '2026-03-23T00:00:00.000Z',
+      '2026-03-23T00:00:00.000Z',
+      null,
+    );
+
+    db.prepare(
+      `
+        INSERT INTO session_summaries (scope_type, scope_id, summary, created_at)
+        VALUES (?, ?, ?, ?)
+      `,
+    ).run('thread', 'be-orphan', 'Resumen ops', '2026-03-24T10:06:00.000Z');
+
+    db.prepare(
+      `
+        INSERT INTO system_events (event_type, status, payload_json, created_at)
+        VALUES (?, ?, ?, ?), (?, ?, ?, ?)
+      `,
+    ).run(
+      'search_query',
+      'error',
+      JSON.stringify({ reason: 'fts down' }),
+      '2026-03-24T10:07:00.000Z',
+      'context_loader',
+      'ok',
+      JSON.stringify({ durationMs: 20, snippetCount: 2 }),
+      '2026-03-24T10:08:00.000Z',
+    );
+
+    enqueueEngineNotification({
+      eventType: 'session.started',
+      targetChatId: 'chat-1',
+      payload: {
+        projectId: 'backend-team',
+        branchName: 'jopen/demo',
+        beadPath: null,
+        workItemKey: 'ops-f2',
+      },
+      createdAt: '2026-03-24T10:09:00.000Z',
+      nextAttemptAt: '2026-03-24T10:09:00.000Z',
+    });
+
+    enqueueEngineNotification({
+      eventType: 'session.synced',
+      targetChatId: 'chat-1',
+      payload: {
+        beadId: 'bead-1',
+        title: 'Aterrizar ops status',
+        branchName: 'jopen/demo',
+        prUrl: 'https://example.test/pr/1',
+      },
+      createdAt: '2026-03-24T10:10:00.000Z',
+      nextAttemptAt: '2026-03-24T10:10:00.000Z',
+    });
+
+    enqueueEngineNotification({
+      eventType: 'session.spawn_failed',
+      payload: {
+        projectId: 'backend-team',
+        branchName: 'jopen/demo',
+        beadPath: null,
+        workItemKey: 'ops-f2',
+        error: 'boom',
+      },
+      createdAt: '2026-03-24T10:11:00.000Z',
+      nextAttemptAt: '2026-03-24T10:11:00.000Z',
+    });
+
+    const notificationRepository = getEngineNotificationRepository();
+    const notifications = notificationRepository.listRecent(10);
+    const delivered = notifications.find((notification) => notification.eventType === 'session.synced');
+    const failed = notifications.find((notification) => notification.eventType === 'session.spawn_failed');
+
+    assert.ok(delivered);
+    assert.ok(failed);
+
+    notificationRepository.markDelivered(delivered.eventId, '2026-03-24T10:12:00.000Z');
+    notificationRepository.markFailed({
+      eventId: failed.eventId,
+      attemptCount: 1,
+      errorMessage: 'No target chat id',
+      terminal: true,
+      failedAt: '2026-03-24T10:13:00.000Z',
+    });
+
+    const status = await getOperationalStatus();
+
+    assert.equal(status.health.db.ok, true);
+    assert.equal(status.health.engine.ok, true);
+    assert.equal(status.health.searchIndex.ok, true);
+
+    assert.equal(status.current.sessions?.totalRecent, 1);
+    assert.equal(status.current.sessions?.active, 1);
+    assert.equal(status.current.sessions?.alive, 0);
+    assert.equal(status.current.sessions?.byStatus.running, 1);
+    assert.equal(status.current.sessions?.byStatus.failed, 0);
+
+    assert.equal(status.current.notificationBacklog?.pending, 1);
+    assert.equal(status.current.notificationBacklog?.delivering, 0);
+    assert.equal(status.current.notificationBacklog?.pendingWithoutTarget, 0);
+
+    assert.equal(status.historical.retrieval?.failedQueries, 1);
+    assert.equal(status.historical.retrieval?.averageRetrievalMs, 20);
+    assert.equal(status.historical.counters?.summaries, 1);
+
+    assert.equal(status.historical.debt.orphanSessions, 1);
+    assert.equal(status.historical.debt.stuckTaskCount, 1);
+    assert.equal(status.historical.debt.stuckTasks[0]?.id, 'task-stale');
+    assert.equal(status.historical.debt.notificationOutbox?.total, 3);
+    assert.equal(status.historical.debt.notificationOutbox?.delivered, 1);
+    assert.equal(status.historical.debt.notificationOutbox?.failed, 1);
+    assert.equal(status.historical.recentEvents[0]?.eventType, 'context_loader');
+    assert.equal(status.historical.recentEvents[1]?.eventType, 'search_query');
+  });
+});

--- a/src/features/ops/observabilityService.ts
+++ b/src/features/ops/observabilityService.ts
@@ -1,7 +1,11 @@
 import { mkdir } from 'fs/promises';
 import path from 'path';
-import { getEngineNotificationRepository } from '../engine/engineNotifications.js';
-import { getEngineSessionsStatus } from '../engine/status.js';
+import {
+  getEngineNotificationRepository,
+  type EngineNotificationSummary,
+} from '../engine/engineNotifications.js';
+import { getEngineSessionsStatus, type EngineStatusSession } from '../engine/status.js';
+import type { RuntimeSessionStatus } from '../engine/runtimeSessionRepository.js';
 import { getRalphitoDatabase, getRalphitoDatabasePath } from '../persistence/db/index.js';
 
 interface EventCountRow {
@@ -28,8 +32,67 @@ interface StuckTaskRow {
   runtimeSessionId: string | null;
 }
 
+export interface OperationalRecentEvent {
+  id: number;
+  eventType: string;
+  status: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+}
+
+export interface OperationalCurrentSessions {
+  totalRecent: number;
+  active: number;
+  alive: number;
+  byStatus: Record<RuntimeSessionStatus, number>;
+}
+
+export interface OperationalNotificationBacklog {
+  pending: number;
+  delivering: number;
+  pendingWithoutTarget: number;
+  oldestOutstandingAt: string | null;
+}
+
+export interface OperationalHistoricalNotificationOutbox {
+  total: number;
+  delivered: number;
+  failed: number;
+  newestCreatedAt: string | null;
+}
+
+export interface OperationalHistoricalDebt {
+  orphanSessions: number | null;
+  stuckTaskCount: number;
+  stuckTasks: StuckTaskRow[];
+  notificationOutbox: OperationalHistoricalNotificationOutbox | null;
+}
+
+export interface OperationalStatus {
+  health: {
+    db: { ok: boolean; error?: string };
+    engine: { ok: boolean; sessionCount?: number; error?: string };
+    searchIndex: { ok: boolean; documentCount?: number; error?: string };
+  };
+  current: {
+    sessions: OperationalCurrentSessions | null;
+    notificationBacklog: OperationalNotificationBacklog | null;
+  };
+  historical: {
+    retrieval: { failedQueries: number; averageRetrievalMs: number } | null;
+    counters: { summaries: number } | null;
+    debt: OperationalHistoricalDebt;
+    recentEvents: OperationalRecentEvent[];
+  };
+  backup: {
+    databasePath: string;
+    backupDir: string;
+  };
+}
+
 const BACKUP_DIR = path.join(process.cwd(), 'ops', 'runtime', 'backups', 'ralphito');
 const STUCK_TASK_MAX_AGE_HOURS = 6;
+const ACTIVE_RUNTIME_SESSION_STATUSES = ['queued', 'running', 'suspended_human_input'] as const satisfies RuntimeSessionStatus[];
 
 export function recordSystemEvent(eventType: string, status: 'ok' | 'warn' | 'error', payload: Record<string, unknown>) {
   const db = getRalphitoDatabase();
@@ -86,19 +149,63 @@ function getAverageRetrievalMs() {
   return Math.round(values.reduce((acc, value) => acc + value, 0) / values.length);
 }
 
-async function getOrphanSessionCount() {
+function createSessionStatusCounts(): Record<RuntimeSessionStatus, number> {
+  return {
+    queued: 0,
+    running: 0,
+    done: 0,
+    failed: 0,
+    cancelled: 0,
+    stuck: 0,
+    suspended_human_input: 0,
+  };
+}
+
+function getCurrentSessions(runtimeSessions: EngineStatusSession[]) {
+  const byStatus = createSessionStatusCounts();
+
+  for (const session of runtimeSessions) {
+    byStatus[session.status as RuntimeSessionStatus] += 1;
+  }
+
+  return {
+    totalRecent: runtimeSessions.length,
+    active: ACTIVE_RUNTIME_SESSION_STATUSES.reduce((count, status) => count + byStatus[status], 0),
+    alive: runtimeSessions.filter((session) => session.alive).length,
+    byStatus,
+  } satisfies OperationalCurrentSessions;
+}
+
+function getNotificationBacklog(summary: EngineNotificationSummary) {
+  return {
+    pending: summary.pending,
+    delivering: summary.delivering,
+    pendingWithoutTarget: summary.pendingWithoutTarget,
+    oldestOutstandingAt: summary.oldestOutstandingAt,
+  } satisfies OperationalNotificationBacklog;
+}
+
+function getHistoricalNotificationOutbox(summary: EngineNotificationSummary) {
+  return {
+    total: summary.total,
+    delivered: summary.delivered,
+    failed: summary.failed,
+    newestCreatedAt: summary.newestCreatedAt,
+  } satisfies OperationalHistoricalNotificationOutbox;
+}
+
+async function getOrphanSessionCount(runtimeSessions: EngineStatusSession[]) {
   const db = getRalphitoDatabase();
-  const runtimeSessions = await getEngineSessionsStatus();
   const activeSessionIds = new Set(runtimeSessions.filter((session) => session.alive).map((session) => session.id));
   const rows = db
     .prepare(
       `
         SELECT runtime_session_id AS runtimeSessionId
         FROM agent_sessions
-        WHERE status IN ('queued', 'running')
+        WHERE status IN (?, ?, ?)
       `,
     )
-    .all() as Array<{ runtimeSessionId: string }>;
+    .all(...ACTIVE_RUNTIME_SESSION_STATUSES) as Array<{ runtimeSessionId: string }>;
 
   return rows.filter((row) => row.runtimeSessionId && !activeSessionIds.has(row.runtimeSessionId)).length;
 }
@@ -138,7 +245,7 @@ function getRecentEvents() {
     status: row.status,
     payload: JSON.parse(row.payloadJson),
     createdAt: row.createdAt,
-  }));
+  })) as OperationalRecentEvent[];
 }
 
 function getDocumentCount() {
@@ -163,13 +270,46 @@ export async function getOperationalStatus() {
     }
   })();
 
+  if (!dbHealth.ok) {
+    return {
+      health: {
+        db: dbHealth,
+        engine: { ok: false, error: 'database unavailable' },
+        searchIndex: { ok: false, error: 'database unavailable' },
+      },
+      current: {
+        sessions: null,
+        notificationBacklog: null,
+      },
+      historical: {
+        retrieval: null,
+        counters: null,
+        debt: {
+          orphanSessions: null,
+          stuckTaskCount: 0,
+          stuckTasks: [],
+          notificationOutbox: null,
+        },
+        recentEvents: [],
+      },
+      backup: {
+        databasePath: getRalphitoDatabasePath(),
+        backupDir: BACKUP_DIR,
+      },
+    } satisfies OperationalStatus;
+  }
+
+  let runtimeSessions: EngineStatusSession[] | null = null;
   const engineHealth = await getEngineSessionsStatus()
-    .then((sessions) => ({ ok: true, sessionCount: sessions.length }))
+    .then((sessions) => {
+      runtimeSessions = sessions;
+      return { ok: true, sessionCount: sessions.length } as const;
+    })
     .catch((error) => ({ ok: false, error: error instanceof Error ? error.message : String(error) }));
 
   const stuckTasks = getStuckTasks();
-  const orphanSessions = await getOrphanSessionCount();
   const notificationSummary = getEngineNotificationRepository().getSummary();
+  const orphanSessions = runtimeSessions ? await getOrphanSessionCount(runtimeSessions) : null;
 
   return {
     health: {
@@ -177,21 +317,31 @@ export async function getOperationalStatus() {
       engine: engineHealth,
       searchIndex: { ok: true, documentCount: getDocumentCount() },
     },
-    metrics: {
-      failedQueries: getFailedQueryCount(),
-      averageRetrievalMs: getAverageRetrievalMs(),
-      orphanSessions,
-      stuckTasks: stuckTasks.length,
-      summaries: getSummaryCount(),
-      notificationOutbox: notificationSummary,
+    current: {
+      sessions: runtimeSessions ? getCurrentSessions(runtimeSessions) : null,
+      notificationBacklog: getNotificationBacklog(notificationSummary),
     },
-    stuckTasks,
-    recentEvents: getRecentEvents(),
+    historical: {
+      retrieval: {
+        failedQueries: getFailedQueryCount(),
+        averageRetrievalMs: getAverageRetrievalMs(),
+      },
+      counters: {
+        summaries: getSummaryCount(),
+      },
+      debt: {
+        orphanSessions,
+        stuckTaskCount: stuckTasks.length,
+        stuckTasks,
+        notificationOutbox: getHistoricalNotificationOutbox(notificationSummary),
+      },
+      recentEvents: getRecentEvents(),
+    },
     backup: {
       databasePath: getRalphitoDatabasePath(),
       backupDir: BACKUP_DIR,
     },
-  };
+  } satisfies OperationalStatus;
 }
 
 export async function backupRalphitoDatabase() {


### PR DESCRIPTION
## Resumen
- separa `health`, `current` y `historical` en ops status
- mueve deuda e historico fuera del semaforo vivo
- agrega test de contrato y actualiza runbook

## Validacion
- node --import tsx --test src/features/ops/observabilityService.test.ts
- node --import tsx --test src/features/engine/runtimePhase4.test.ts
- npx tsc --noEmit